### PR TITLE
Update RPC endpoint for tutorials

### DIFF
--- a/docs/miden_node_setup.md
+++ b/docs/miden_node_setup.md
@@ -101,5 +101,5 @@ rm -rf node/storage/blocks
 To run the tutorial examples using the Miden testnet, use this endpoint:
 
 ```bash
-https://rpc.devnet.miden.io:443
+https://rpc.testnet.miden.io:443
 ```

--- a/docs/rust-client/counter_contract_tutorial.md
+++ b/docs/rust-client/counter_contract_tutorial.md
@@ -77,7 +77,7 @@ pub async fn initialize_client() -> Result<Client<RpoRandomCoin>, ClientError> {
     // RPC endpoint and timeout
     let endpoint = Endpoint::new(
         "https".to_string(),
-        "rpc.devnet.miden.io".to_string(),
+        "rpc.testnet.miden.io".to_string(),
         Some(443),
     );
     let timeout_ms = 10_000;
@@ -442,7 +442,7 @@ pub async fn initialize_client() -> Result<Client<RpoRandomCoin>, ClientError> {
     // RPC endpoint and timeout
     let endpoint = Endpoint::new(
         "https".to_string(),
-        "rpc.devnet.miden.io".to_string(),
+        "rpc.testnet.miden.io".to_string(),
         Some(443),
     );
     let timeout_ms = 10_000;

--- a/rust-client/src/bin/counter_contract_increment.rs
+++ b/rust-client/src/bin/counter_contract_increment.rs
@@ -25,7 +25,7 @@ pub async fn initialize_client() -> Result<Client<RpoRandomCoin>, ClientError> {
     // RPC endpoint and timeout
     let endpoint = Endpoint::new(
         "https".to_string(),
-        "rpc.devnet.miden.io".to_string(),
+        "rpc.testnet.miden.io".to_string(),
         Some(443),
     );
     let timeout_ms = 10_000;


### PR DESCRIPTION
Updating the RPC endpoint to use the new testnet URL for the tutorials. 