### PR TITLE
Adding about section to remove gray unclickable text on docs page

### DIFF
--- a/docs/rust-client/about.md
+++ b/docs/rust-client/about.md
@@ -1,0 +1,11 @@
+# Rust Client
+
+The Miden Rust client can be used for a variety of things, including:
+
+* Deploying, testing, and creating transactions to interact with accounts and notes on Miden.
+* Storing the state of accounts and notes locally.
+* Generating and submitting proofs of transactions.
+
+This section of the docs is an overview of the different things one can achieve using the Rust client, and how to implement them. 
+
+Keep in mind that both the Rust client and the documentation are works-in-progress!

--- a/docs/web-client/about.md
+++ b/docs/web-client/about.md
@@ -1,0 +1,12 @@
+# Web Client
+
+The Miden Web client can be used for a variety of things, including:
+
+* Deploying and creating transactions to interact with accounts and notes on Miden.
+* Storing the state of accounts and notes in the browser.
+* Generating and submitting proofs of transactions.
+* Submitting transactions to delegated proving services.
+
+This section of the docs is an overview of the different things one can achieve using the Web client, and how to implement them. 
+
+Keep in mind that both the Web client and the documentation are works-in-progress!


### PR DESCRIPTION
Adding about section to remove gray unclickable text on docs page. These two about.md files explain what each section is. 