### PR TITLE
chore: Slack notification on failed CI runs

### DIFF
--- a/.github/workflows/doc-tests.yml
+++ b/.github/workflows/doc-tests.yml
@@ -29,3 +29,12 @@ jobs:
           rustup update --no-self-update
           cargo test --doc --release -- --test-threads=1
         working-directory: docs
+
+      - name: Notify Slack on Failure
+        if: failure()
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          text: '❌ Documentation tests failed on ${{ github.ref }}'
+          webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          fields: repo,message,commit,author,action,eventName,ref,workflow


### PR DESCRIPTION
builds on top of #96