### PR TITLE
chore: update tutorial instructions to use webpack instead of turbopack

### DIFF
--- a/docs/src/web-client/counter_contract_tutorial.md
+++ b/docs/src/web-client/counter_contract_tutorial.md
@@ -47,13 +47,13 @@ This tutorial assumes you have a basic understanding of Miden assembly. To quick
    pnpm i @demox-labs/miden-sdk@0.11.1
    ```
 
-**NOTE!**: Be sure to remove the `--turbopack` command from your `package.json` when running the `dev script`. The dev script should look like this:
+**NOTE!**: Be sure to add the `--webpack` command to your `package.json` when running the `dev script`. The dev script should look like this:
 
 `package.json`
 
 ```json
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --webpack",
     ...
   }
 ```

--- a/docs/src/web-client/create_deploy_tutorial.md
+++ b/docs/src/web-client/create_deploy_tutorial.md
@@ -58,13 +58,13 @@ It is useful to think of notes on Miden as "cryptographic cashier's checks" that
    pnpm install @demox-labs/miden-sdk@0.11.1
    ```
 
-**NOTE!**: Be sure to remove the `--turbopack` command from your `package.json` when running the `dev script`. The dev script should look like this:
+**NOTE!**: Be sure to add the `--webpack` command to your `package.json` when running the `dev script`. The dev script should look like this:
 
 `package.json`
 
 ```json
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --webpack",
     ...
   }
 ```

--- a/docs/src/web-client/creating_multiple_notes_tutorial.md
+++ b/docs/src/web-client/creating_multiple_notes_tutorial.md
@@ -60,13 +60,13 @@ Anyone can run their own delegated prover server. If you are building a product 
    pnpm install @demox-labs/miden-sdk@0.11.1
    ```
 
-**NOTE!**: Be sure to remove the `--turbopack` command from your `package.json` when running the `dev script`. The dev script should look like this:
+**NOTE!**: Be sure to add the `--webpack` command to your `package.json` when running the `dev script`. The dev script should look like this:
 
 `package.json`
 
 ```json
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --webpack",
     ...
   }
 ```

--- a/docs/src/web-client/foreign_procedure_invocation_tutorial.md
+++ b/docs/src/web-client/foreign_procedure_invocation_tutorial.md
@@ -60,13 +60,13 @@ This tutorial assumes you have a basic understanding of Miden assembly and compl
    pnpm i @demox-labs/miden-sdk@0.11.1
    ```
 
-**NOTE!**: Be sure to remove the `--turbopack` command from your `package.json` when running the `dev script`. The dev script should look like this:
+**NOTE!**: Be sure to add the `--webpack` command to your `package.json` when running the `dev script`. The dev script should look like this:
 
 `package.json`
 
 ```json
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --webpack",
     ...
   }
 ```

--- a/docs/src/web-client/unauthenticated_note_how_to.md
+++ b/docs/src/web-client/unauthenticated_note_how_to.md
@@ -80,13 +80,13 @@ This tutorial assumes you have a basic understanding of Miden assembly. To quick
    pnpm install @demox-labs/miden-sdk@0.11.1
    ```
 
-**NOTE!**: Be sure to remove the `--turbopack` command from your `package.json` when running the `dev script`. The dev script should look like this:
+**NOTE!**: Be sure to add the `--webpack` command to your `package.json` when running the `dev script`. The dev script should look like this:
 
 `package.json`
 
 ```json
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --webpack",
     ...
   }
 ```


### PR DESCRIPTION
This PR mirrors the changes from this PR on the miden-docs repository: https://github.com/0xMiden/miden-docs/pull/93