### PR TITLE
chore: add custom prettier config for web client code

### DIFF
--- a/web-client/.prettierrc
+++ b/web-client/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "printWidth": 80,
+  "tabWidth": 2,
+  "singleQuote": true,
+  "trailingComma": "all"
+}


### PR DESCRIPTION
As discussed with @WiktorStarczewski on Slack, we propose changing the prettier settings for Typescript code to use single quotes instead of double quotes, as this is a more common pattern in Javascript/Typescript code.