### PR TITLE
Matching the number of accounts with the withdrawal example

### DIFF
--- a/docs/src/rust-client/unauthenticated_note_how_to.md
+++ b/docs/src/rust-client/unauthenticated_note_how_to.md
@@ -178,7 +178,7 @@ async fn main() -> Result<(), ClientError> {
     println!("\n[STEP 2] Creating new accounts");
 
     let mut accounts = vec![];
-    let number_of_accounts = 2;
+    let number_of_accounts = 10;
 
     for i in 0..number_of_accounts {
         let mut init_seed = [0_u8; 32];


### PR DESCRIPTION
Changed `number_of_accounts` to 10 so that the code example matches the output shown with 10 “unauthenticated tx” accounts:
<img width="454" height="248" alt="image" src="https://github.com/user-attachments/assets/e0afbf4a-ac8e-432f-9423-20953b69cbf2" />
