### PR TITLE
docs: fix incorrect step reference in node reset instructions

### DIFF
--- a/docs/src/miden_node_setup.md
+++ b/docs/src/miden_node_setup.md
@@ -86,7 +86,7 @@ rm -r data
 rm -r accounts
 ```
 
-After resetting the state of the node, follow steps 2 and 4 again.
+After resetting the state of the node, follow steps 2 and 3 again.
 
 ## Connecting to the Miden testnet
 


### PR DESCRIPTION
## Summary
Fixed incorrect step reference in the "Resetting the node" section of the Miden Node Setup tutorial.

## Changes
- Changed "steps 2 and 4" to "steps 2 and 3" on line 89

## Issue
The tutorial only documents 3 steps for setting up a local Miden node:
1. Install the Miden node
2. Initialize the node (generate genesis file)
3. Start the node

The reset instructions incorrectly referenced "step 4" which doesn't exist, potentially confusing developers following the tutorial.

## Testing
Verified that the documentation now correctly references the existing steps.