### PR TITLE
docs(rust-client): explain refreshed account state before balance checks

### DIFF
--- a/docs/src/rust-client/mint_consume_create_tutorial.md
+++ b/docs/src/rust-client/mint_consume_create_tutorial.md
@@ -128,6 +128,26 @@ loop {
     }
 }
 ```
+If you want to verify Alice's updated balance after consuming notes, fetch the account again from the client store before checking `vault().get_balance(...)`.
+The `alice_account` variable created earlier still points to the initial in-memory account state.
+
+Add this import if it is not already present:
+
+```rust ignore
+use miden_client::store::AccountRecordData;
+```
+
+```rust ignore
+let alice_account_record = client.get_account(alice_account.id()).await?.unwrap();
+let alice_account = match alice_account_record.account_data() {
+    AccountRecordData::Full(account) => account,
+    AccountRecordData::Partial(_) => panic!("alice account is missing full account data"),
+};
+
+let alice_balance = alice_account.vault().get_balance(faucet_account.id()).unwrap();
+println!("Alice's updated balance: {:?}", alice_balance);
+```
+
 
 ## Step 4: Sending tokens to other accounts
 


### PR DESCRIPTION
## Current behavior

The tutorial says Alice's wallet balance is updated after consuming notes, but it does not explain that the previously created `alice_account` variable may still reflect stale in-memory state.  
As a result, users may read `vault().get_balance(...)` from stale data and see `Ok(0)`.

## New behavior

The tutorial now explicitly explains that users should re-fetch Alice's account from the client store before checking balances.  
A concrete code snippet is added, including `AccountRecordData` handling and an updated balance print example.

## Breaking changes

None.

## Other info

Documentation-only update for Rust tutorial clarity.
Linked issue: #114
Closes #114