### PR TITLE
docs(rust-client): fix step numbering in create/deploy tutorial

### DIFF
--- a/docs/src/rust-client/create_deploy_tutorial.md
+++ b/docs/src/rust-client/create_deploy_tutorial.md
@@ -153,9 +153,9 @@ Add this snippet to the end of your file in the `main()` function:
 
 ```rust ignore
 //------------------------------------------------------------
-// STEP 1: Create a basic wallet for Alice
+// STEP 3: Create a basic wallet for Alice
 //------------------------------------------------------------
-println!("\n[STEP 1] Creating a new account for Alice");
+println!("\n[STEP 3] Creating a new account for Alice");
 
 // Account seed
 let mut init_seed = [0_u8; 32];
@@ -192,9 +192,9 @@ Add this snippet to the end of your file in the `main()` function:
 
 ```rust ignore
 //------------------------------------------------------------
-// STEP 2: Deploy a fungible faucet
+// STEP 4: Deploy a fungible faucet
 //------------------------------------------------------------
-println!("\n[STEP 2] Deploying a new fungible faucet.");
+println!("\n[STEP 4] Deploying a new fungible faucet.");
 
 // Faucet seed
 let mut init_seed = [0u8; 32];
@@ -290,9 +290,9 @@ async fn main() -> Result<(), ClientError> {
     println!("Latest block: {}", sync_summary.block_num);
 
     //------------------------------------------------------------
-    // STEP 1: Create a basic wallet for Alice
+    // STEP 3: Create a basic wallet for Alice
     //------------------------------------------------------------
-    println!("\n[STEP 1] Creating a new account for Alice");
+    println!("\n[STEP 3] Creating a new account for Alice");
 
     // Account seed
     let mut init_seed = [0_u8; 32];
@@ -319,9 +319,9 @@ async fn main() -> Result<(), ClientError> {
     println!("Alice's account ID: {:?}", alice_account_id_bech32);
 
     //------------------------------------------------------------
-    // STEP 2: Deploy a fungible faucet
+    // STEP 4: Deploy a fungible faucet
     //------------------------------------------------------------
-    println!("\n[STEP 2] Deploying a new fungible faucet.");
+    println!("\n[STEP 4] Deploying a new fungible faucet.");
 
     // Faucet seed
     let mut init_seed = [0u8; 32];
@@ -372,10 +372,10 @@ The output will look like this:
 ```text
 Latest block: 17771
 
-[STEP 1] Creating a new account for Alice
+[STEP 3] Creating a new account for Alice
 Alice's account ID: "0x3cb3e596d14ad410000017901eaa7b"
 
-[STEP 2] Deploying a new fungible faucet.
+[STEP 4] Deploying a new fungible faucet.
 Faucet account ID: "0x6ad1894ac233e4200000088311bb6b"
 ```
 


### PR DESCRIPTION
## Current behavior

The Rust create/deploy tutorial uses step headers for "Step 3" and "Step 4", but several inline code comments and example output lines still use "STEP 1" and "STEP 2".

This makes the tutorial flow inconsistent and can confuse readers when following the examples.

## New behavior

The inline code labels and example output in `create_deploy_tutorial.md` are updated to match the section headers:

- wallet creation labels now use `STEP 3`
- faucet deployment labels now use `STEP 4`

The tutorial text, embedded code snippets, summary section, and sample output are now consistent.

## Breaking changes

None.

## Other info

Documentation-only update for tutorial consistency.
Closes #93