### PR TITLE
fix: deploy tutorial addresses on both testnet and devnet

### DIFF
--- a/docs/src/rust-client/foreign_procedure_invocation_tutorial.md
+++ b/docs/src/rust-client/foreign_procedure_invocation_tutorial.md
@@ -270,7 +270,7 @@ println!("\n[STEP 2] Building counter contract from public state");
 
 // Define the Counter Contract account id from counter contract deploy
 let (_, counter_contract_id) =
-    AccountId::from_bech32("mtst1az62d8rhnf00kqp80k3klwy56c6w9gvm").unwrap();
+    AccountId::from_bech32("mtst1aq8hpfmr4zhq7qr4dfwn07djwy6lmags").unwrap();
 
 println!("counter contract id: {:?}", counter_contract_id);
 
@@ -558,7 +558,7 @@ async fn main() -> Result<(), ClientError> {
 
     // Define the Counter Contract account id from counter contract deploy
     let (_, counter_contract_id) =
-        AccountId::from_bech32("mtst1az62d8rhnf00kqp80k3klwy56c6w9gvm").unwrap();
+        AccountId::from_bech32("mtst1aq8hpfmr4zhq7qr4dfwn07djwy6lmags").unwrap();
 
     println!("counter contract id: {:?}", counter_contract_id);
 

--- a/docs/src/rust-client/foreign_procedure_invocation_tutorial.md
+++ b/docs/src/rust-client/foreign_procedure_invocation_tutorial.md
@@ -270,7 +270,7 @@ println!("\n[STEP 2] Building counter contract from public state");
 
 // Define the Counter Contract account id from counter contract deploy
 let (_, counter_contract_id) =
-    AccountId::from_bech32("mtst1arjemrxne8lj5qz4mg9c8mtyxg954483").unwrap();
+    AccountId::from_bech32("mtst1az62d8rhnf00kqp80k3klwy56c6w9gvm").unwrap();
 
 println!("counter contract id: {:?}", counter_contract_id);
 
@@ -558,7 +558,7 @@ async fn main() -> Result<(), ClientError> {
 
     // Define the Counter Contract account id from counter contract deploy
     let (_, counter_contract_id) =
-        AccountId::from_bech32("mtst1arjemrxne8lj5qz4mg9c8mtyxg954483").unwrap();
+        AccountId::from_bech32("mtst1az62d8rhnf00kqp80k3klwy56c6w9gvm").unwrap();
 
     println!("counter contract id: {:?}", counter_contract_id);
 

--- a/docs/src/rust-client/oracle_tutorial.md
+++ b/docs/src/rust-client/oracle_tutorial.md
@@ -312,7 +312,9 @@ _Don't run this code just yet, we still need to create our smart contract that q
 
 In the code above, we specified the Pragma oracle account id `0x4f67e78643022e00000220d8997e33` and the BTC/USD pair `120195681`. The `get_oracle_foreign_accounts` function returns all of the `ForeignAccounts` that you will need to execute the transaction to get the price data from the oracle. Since Pragma's oracle depends on multiple publishers, this function queries all of the publisher account ids required to make a successful FPI call.
 
-To learn more about Pragma's oracle architecture, you can look at the source code here: https://github.com/astraly-labs/pragma-miden
+:::note
+The oracle account ID, procedure hash, and trading pair ID used in this tutorial reference Pragma's testnet deployment. These values are maintained by Pragma and may change if they redeploy their oracle. For the latest values, check the [Pragma Miden repository](https://github.com/astraly-labs/pragma-miden).
+:::
 
 ## Step 2: Build the price reader smart contract and script
 
@@ -344,7 +346,7 @@ The import `miden::tx` contains the `tx::execute_foreign_procedure` which we wil
 
 1. Pushes `0.0.0.120195681` onto the stack, representing the BTC/USD pair in the Pragma oracle.
 2. Pushes `0xb86237a8c9cd35acfef457e47282cc4da43df676df410c988eab93095d8fb3b9` onto the stack which is the procedure root of the `get_median` procedure in the oracle.
-3. Pushes `599064613630720.5721796415433354752` onto the stack which is the oracle id prefix and suffix.
+3. Pushes `939716883672832.2172042075194638080` onto the stack which is the oracle id prefix and suffix.
 4. Calls `tx::execute_foreign_procedure` which calls the `get_median` procedure via foreign procedure invocation.
 
 Inside of the `masm/accounts/` directory, create the `oracle_reader.masm` file:

--- a/docs/src/rust-client/public_account_interaction_tutorial.md
+++ b/docs/src/rust-client/public_account_interaction_tutorial.md
@@ -201,7 +201,7 @@ println!("\n[STEP 1] Reading data from public state");
 
 // Define the Counter Contract account id from counter contract deploy
 let (_, counter_contract_id) =
-    AccountId::from_bech32("mtst1az62d8rhnf00kqp80k3klwy56c6w9gvm").unwrap();
+    AccountId::from_bech32("mtst1aq8hpfmr4zhq7qr4dfwn07djwy6lmags").unwrap();
 
 client
     .import_account_by_id(counter_contract_id)
@@ -379,7 +379,7 @@ async fn main() -> Result<(), ClientError> {
 
     // Define the Counter Contract account id from counter contract deploy
     let (_, counter_contract_id) =
-        AccountId::from_bech32("mtst1az62d8rhnf00kqp80k3klwy56c6w9gvm").unwrap();
+        AccountId::from_bech32("mtst1aq8hpfmr4zhq7qr4dfwn07djwy6lmags").unwrap();
 
     client
         .import_account_by_id(counter_contract_id)

--- a/docs/src/rust-client/public_account_interaction_tutorial.md
+++ b/docs/src/rust-client/public_account_interaction_tutorial.md
@@ -201,7 +201,7 @@ println!("\n[STEP 1] Reading data from public state");
 
 // Define the Counter Contract account id from counter contract deploy
 let (_, counter_contract_id) =
-    AccountId::from_bech32("mtst1arjemrxne8lj5qz4mg9c8mtyxg954483").unwrap();
+    AccountId::from_bech32("mtst1az62d8rhnf00kqp80k3klwy56c6w9gvm").unwrap();
 
 client
     .import_account_by_id(counter_contract_id)
@@ -379,7 +379,7 @@ async fn main() -> Result<(), ClientError> {
 
     // Define the Counter Contract account id from counter contract deploy
     let (_, counter_contract_id) =
-        AccountId::from_bech32("mtst1arjemrxne8lj5qz4mg9c8mtyxg954483").unwrap();
+        AccountId::from_bech32("mtst1az62d8rhnf00kqp80k3klwy56c6w9gvm").unwrap();
 
     client
         .import_account_by_id(counter_contract_id)

--- a/docs/src/web-client/counter_contract_tutorial.md
+++ b/docs/src/web-client/counter_contract_tutorial.md
@@ -206,7 +206,7 @@ export async function incrementCounterContract(): Promise<void> {
 
   // Import the counter contract from testnet by its bech32 address
   const counterContractAccount = await client.accounts.getOrImport(
-    'mtst1arjemrxne8lj5qz4mg9c8mtyxg954483',
+    'mtst1az62d8rhnf00kqp80k3klwy56c6w9gvm',
   );
 
   const counterSlotName = 'miden::tutorials::counter';

--- a/docs/src/web-client/counter_contract_tutorial.md
+++ b/docs/src/web-client/counter_contract_tutorial.md
@@ -206,7 +206,7 @@ export async function incrementCounterContract(): Promise<void> {
 
   // Import the counter contract from testnet by its bech32 address
   const counterContractAccount = await client.accounts.getOrImport(
-    'mtst1az62d8rhnf00kqp80k3klwy56c6w9gvm',
+    'mtst1aq8hpfmr4zhq7qr4dfwn07djwy6lmags',
   );
 
   const counterSlotName = 'miden::tutorials::counter';

--- a/docs/src/web-client/foreign_procedure_invocation_tutorial.md
+++ b/docs/src/web-client/foreign_procedure_invocation_tutorial.md
@@ -294,7 +294,7 @@ export async function foreignProcedureInvocation(): Promise<void> {
 
   // Import the counter contract from testnet by its bech32 address
   let counterContractAccount = await client.accounts.getOrImport(
-    'mtst1arjemrxne8lj5qz4mg9c8mtyxg954483',
+    'mtst1az62d8rhnf00kqp80k3klwy56c6w9gvm',
   );
   console.log(
     'Account storage slot:',

--- a/docs/src/web-client/foreign_procedure_invocation_tutorial.md
+++ b/docs/src/web-client/foreign_procedure_invocation_tutorial.md
@@ -294,7 +294,7 @@ export async function foreignProcedureInvocation(): Promise<void> {
 
   // Import the counter contract from testnet by its bech32 address
   let counterContractAccount = await client.accounts.getOrImport(
-    'mtst1az62d8rhnf00kqp80k3klwy56c6w9gvm',
+    'mtst1aq8hpfmr4zhq7qr4dfwn07djwy6lmags',
   );
   console.log(
     'Account storage slot:',

--- a/masm/accounts/oracle_reader.masm
+++ b/masm/accounts/oracle_reader.masm
@@ -1,6 +1,10 @@
+# The oracle account ID, procedure hash, and pair ID below reference
+# Pragma's testnet deployment (https://github.com/astraly-labs/pragma-miden).
+# If Pragma redeploys their oracle, these values must be updated.
+
 use miden::protocol::tx
 
-# Fetches the current price from the `get_median` 
+# Fetches the current price from the `get_median`
 # procedure from the Pragma oracle
 # => []
 pub proc get_price

--- a/rust-client/src/bin/counter_contract_fpi.rs
+++ b/rust-client/src/bin/counter_contract_fpi.rs
@@ -122,7 +122,7 @@ async fn main() -> Result<(), ClientError> {
 
     // Define the Counter Contract account id from counter contract deploy
     let (_, counter_contract_id) =
-        AccountId::from_bech32("mtst1az62d8rhnf00kqp80k3klwy56c6w9gvm").unwrap();
+        AccountId::from_bech32("mtst1aq8hpfmr4zhq7qr4dfwn07djwy6lmags").unwrap();
 
     println!("counter contract id: {:?}", counter_contract_id);
 

--- a/rust-client/src/bin/counter_contract_fpi.rs
+++ b/rust-client/src/bin/counter_contract_fpi.rs
@@ -122,7 +122,7 @@ async fn main() -> Result<(), ClientError> {
 
     // Define the Counter Contract account id from counter contract deploy
     let (_, counter_contract_id) =
-        AccountId::from_bech32("mtst1apfclszryn8a5qqae6sa6hscfgn4mnqp").unwrap();
+        AccountId::from_bech32("mtst1az62d8rhnf00kqp80k3klwy56c6w9gvm").unwrap();
 
     println!("counter contract id: {:?}", counter_contract_id);
 

--- a/rust-client/src/bin/counter_contract_increment.rs
+++ b/rust-client/src/bin/counter_contract_increment.rs
@@ -60,7 +60,7 @@ async fn main() -> Result<(), ClientError> {
 
     // Define the Counter Contract account id from counter contract deploy
     let (_, counter_contract_id) =
-        AccountId::from_bech32("mtst1apfclszryn8a5qqae6sa6hscfgn4mnqp").unwrap();
+        AccountId::from_bech32("mtst1az62d8rhnf00kqp80k3klwy56c6w9gvm").unwrap();
 
     client
         .import_account_by_id(counter_contract_id)

--- a/rust-client/src/bin/counter_contract_increment.rs
+++ b/rust-client/src/bin/counter_contract_increment.rs
@@ -60,7 +60,7 @@ async fn main() -> Result<(), ClientError> {
 
     // Define the Counter Contract account id from counter contract deploy
     let (_, counter_contract_id) =
-        AccountId::from_bech32("mtst1az62d8rhnf00kqp80k3klwy56c6w9gvm").unwrap();
+        AccountId::from_bech32("mtst1aq8hpfmr4zhq7qr4dfwn07djwy6lmags").unwrap();
 
     client
         .import_account_by_id(counter_contract_id)


### PR DESCRIPTION
Before a testnet upgrade, we need to test all tutorials against devnet since testnet won't be running the next release version yet. This requires that any hardcoded account addresses referenced by tutorials exist on both networks.

This PR deploys the counter contract with a deterministic seed on both testnet and devnet and updates all eight references (two in code, six in docs) to the new unified address (`mtst1az62d8rhnf00kqp80k3klwy56c6w9gvm`). The address works on both networks since `AccountId::from_bech32` discards the network prefix and the deterministic seed produces the same `AccountId` regardless of network.

Also fixes a prose/code mismatch in the oracle tutorial where the inline `prefix.suffix` values didn't match the MASM file, and adds a Pragma dependency comment to `oracle_reader.masm`.

Closes #175