### PR TITLE
fix(web-client): replace yarn create with npx create in tutorials

### DIFF
--- a/docs/src/web-client/counter_contract_tutorial.md
+++ b/docs/src/web-client/counter_contract_tutorial.md
@@ -29,7 +29,7 @@ This tutorial assumes you have a basic understanding of Miden assembly. To quick
 1. Create a new Next.js app with TypeScript:
 
    ```bash
-   yarn create next-app@latest miden-web-app --typescript
+   npx create-next-app@latest miden-web-app --typescript
    ```
 
    Hit enter for all terminal prompts.

--- a/docs/src/web-client/create_deploy_tutorial.md
+++ b/docs/src/web-client/create_deploy_tutorial.md
@@ -42,7 +42,7 @@ It is useful to think of notes on Miden as "cryptographic cashier's checks" that
 1. Create a new Next.js app with TypeScript:
 
    ```bash
-   yarn create next-app@latest miden-web-app --typescript
+   npx create-next-app@latest miden-web-app --typescript
    ```
 
    Hit enter for all terminal prompts.

--- a/docs/src/web-client/creating_multiple_notes_tutorial.md
+++ b/docs/src/web-client/creating_multiple_notes_tutorial.md
@@ -47,7 +47,7 @@ proving service. This means your browser never has to generate the full ZK proof
 1. Create a new Next.js app with TypeScript:
 
    ```bash
-   yarn create next-app@latest miden-web-app --typescript
+   npx create-next-app@latest miden-web-app --typescript
    ```
 
    Hit enter for all terminal prompts.

--- a/docs/src/web-client/foreign_procedure_invocation_tutorial.md
+++ b/docs/src/web-client/foreign_procedure_invocation_tutorial.md
@@ -44,7 +44,7 @@ This tutorial assumes you have a basic understanding of Miden assembly and compl
 1. Create a new Next.js app with TypeScript:
 
    ```bash
-   yarn create next-app@latest miden-fpi-app --typescript
+   npx create-next-app@latest miden-fpi-app --typescript
    ```
 
    Hit enter for all terminal prompts.

--- a/docs/src/web-client/react_wallet_tutorial.md
+++ b/docs/src/web-client/react_wallet_tutorial.md
@@ -43,7 +43,7 @@ First, create a new Vite + React project and install the Miden React SDK.
 1. Create a new Vite project with React and TypeScript:
 
    ```bash
-   yarn create vite miden-wallet --template react-ts
+   npx create-vite@latest miden-wallet --template react-ts
    cd miden-wallet
    ```
 

--- a/docs/src/web-client/unauthenticated_note_how_to.md
+++ b/docs/src/web-client/unauthenticated_note_how_to.md
@@ -65,7 +65,7 @@ This tutorial assumes you have a basic understanding of Miden assembly. To quick
 1. Create a new Next.js app with TypeScript:
 
    ```bash
-   yarn create next-app@latest miden-web-app --typescript
+   npx create-next-app@latest miden-web-app --typescript
    ```
 
    Hit enter for all terminal prompts.


### PR DESCRIPTION
Closes #178

## Summary

On Linux with Yarn Classic (v1.22.x), `yarn create next-app@latest` resolves to an outdated `create-next-app` version instead of the latest, then fails with exit code 127. This is a known Yarn Classic v1.x bug with `@latest` tag resolution. `npx` handles version resolution correctly across all platforms.

Replaces all `yarn create` commands with their `npx create` equivalents across the 6 web client tutorial docs.

Reported in 0xMiden/miden-client#1927.

Closes #178