### PR TITLE
refactor: use `CodeBuilder`

### DIFF
--- a/docs/src/rust-client/counter_contract_tutorial.md
+++ b/docs/src/rust-client/counter_contract_tutorial.md
@@ -55,20 +55,12 @@ Copy and paste the following code into your `src/main.rs` file:
 
 ```rust no_run
 use miden_client::auth::NoAuth;
-use miden_client::transaction::TransactionKernel;
 use rand::RngCore;
 use std::{fs, path::Path, sync::Arc};
 
 use miden_client::{
     address::NetworkId,
-    assembly::{
-        Assembler,
-        CodeBuilder,
-        DefaultSourceManager,
-        Module,
-        ModuleKind,
-        Path as AssemblyPath,
-    },
+    assembly::CodeBuilder,
     builder::ClientBuilder,
     keystore::FilesystemKeyStore,
     rpc::{Endpoint, GrpcClient},
@@ -83,21 +75,6 @@ use miden_client::{
     },
     Word,
 };
-
-fn create_library(
-    library_path: &str,
-    source_code: &str,
-) -> Result<std::sync::Arc<miden_client::assembly::Library>, Box<dyn std::error::Error>> {
-    let source_manager = Arc::new(DefaultSourceManager::default());
-    let assembler = TransactionKernel::assembler_with_source_manager(source_manager.clone());
-    let module = Module::parser(ModuleKind::Library).parse_str(
-        AssemblyPath::new(library_path),
-        source_code,
-        source_manager,
-    )?;
-    let library = assembler.assemble_library([module])?;
-    Ok(library)
-}
 
 #[tokio::main]
 async fn main() -> Result<(), ClientError> {
@@ -327,16 +304,9 @@ println!("\n[STEP 2] Call Counter Contract With Script");
 let script_path = Path::new("../masm/scripts/counter_script.masm");
 let script_code = fs::read_to_string(script_path).unwrap();
 
-// Create a library from the counter contract code
-let account_component_lib = create_library(
-    "external_contract::counter_contract",
-    &counter_code,
-)
-.unwrap();
-
 let tx_script = client
     .code_builder()
-    .with_dynamically_linked_library(&account_component_lib)
+    .with_dynamically_linked_library(counter_component.component_code())
     .unwrap()
     .compile_tx_script(&script_code)
     .unwrap();
@@ -385,20 +355,12 @@ The final `src/main.rs` file should look like this:
 
 ```rust no_run
 use miden_client::auth::NoAuth;
-use miden_client::transaction::TransactionKernel;
 use rand::RngCore;
 use std::{fs, path::Path, sync::Arc};
 
 use miden_client::{
     address::NetworkId,
-    assembly::{
-        Assembler,
-        CodeBuilder,
-        DefaultSourceManager,
-        Module,
-        ModuleKind,
-        Path as AssemblyPath,
-    },
+    assembly::CodeBuilder,
     builder::ClientBuilder,
     keystore::FilesystemKeyStore,
     rpc::{Endpoint, GrpcClient},
@@ -413,21 +375,6 @@ use miden_client::{
     },
     Word,
 };
-
-fn create_library(
-    library_path: &str,
-    source_code: &str,
-) -> Result<std::sync::Arc<miden_client::assembly::Library>, Box<dyn std::error::Error>> {
-    let source_manager = Arc::new(DefaultSourceManager::default());
-    let assembler = TransactionKernel::assembler_with_source_manager(source_manager.clone());
-    let module = Module::parser(ModuleKind::Library).parse_str(
-        AssemblyPath::new(library_path),
-        source_code,
-        source_manager,
-    )?;
-    let library = assembler.assemble_library([module])?;
-    Ok(library)
-}
 
 #[tokio::main]
 async fn main() -> Result<(), ClientError> {
@@ -506,16 +453,9 @@ async fn main() -> Result<(), ClientError> {
     let script_path = Path::new("../masm/scripts/counter_script.masm");
     let script_code = fs::read_to_string(script_path).unwrap();
 
-    // Create a library from the counter contract code
-    let account_component_lib = create_library(
-        "external_contract::counter_contract",
-        &counter_code,
-    )
-    .unwrap();
-
     let tx_script = client
         .code_builder()
-        .with_dynamically_linked_library(&account_component_lib)
+        .with_dynamically_linked_library(counter_component.component_code())
         .unwrap()
         .compile_tx_script(&script_code)
         .unwrap();

--- a/docs/src/rust-client/foreign_procedure_invocation_tutorial.md
+++ b/docs/src/rust-client/foreign_procedure_invocation_tutorial.md
@@ -134,37 +134,15 @@ use miden_client::{
         AccountStorageMode, AccountType, StorageSlot, StorageSlotName,
     },
     account::AccountId,
-    assembly::{
-        CodeBuilder,
-        DefaultSourceManager,
-        Library,
-        Module,
-        ModuleKind,
-        Path as AssemblyPath,
-    },
+    assembly::CodeBuilder,
     auth::NoAuth,
     builder::ClientBuilder,
     keystore::FilesystemKeyStore,
     rpc::{domain::account::AccountStorageRequirements, Endpoint, GrpcClient},
-    transaction::{ForeignAccount, TransactionKernel, TransactionRequestBuilder},
+    transaction::{ForeignAccount, TransactionRequestBuilder},
     ClientError, Word,
 };
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
-
-fn create_library(
-    library_path: &str,
-    source_code: &str,
-) -> Result<Arc<Library>, Box<dyn std::error::Error>> {
-    let source_manager = Arc::new(DefaultSourceManager::default());
-    let assembler = TransactionKernel::assembler_with_source_manager(source_manager.clone());
-    let module = Module::parser(ModuleKind::Library).parse_str(
-        AssemblyPath::new(library_path),
-        source_code,
-        source_manager,
-    )?;
-    let library = assembler.assemble_library([module])?;
-    Ok(library)
-}
 
 #[tokio::main]
 async fn main() -> Result<(), ClientError> {
@@ -336,15 +314,9 @@ let script_code = script_code_original
         &u64::from(counter_contract_id.prefix()).to_string(),
     );
 
-let account_component_lib = create_library(
-    "external_contract::count_reader_contract",
-    &count_reader_code,
-)
-.unwrap();
-
 let tx_script = client
     .code_builder()
-    .with_dynamically_linked_library(&account_component_lib)
+    .with_dynamically_linked_library(count_reader_component.component_code())
     .unwrap()
     .compile_tx_script(&script_code)
     .unwrap();
@@ -414,33 +386,15 @@ use miden_client::{
         component::AccountComponentMetadata, AccountBuilder, AccountComponent, AccountId,
         AccountStorageMode, AccountType, StorageSlot, StorageSlotName,
     },
-    assembly::{
-        CodeBuilder, DefaultSourceManager, Library, Module, ModuleKind,
-        Path as AssemblyPath,
-    },
+    assembly::CodeBuilder,
     auth::NoAuth,
     builder::ClientBuilder,
     keystore::FilesystemKeyStore,
     rpc::{domain::account::AccountStorageRequirements, Endpoint, GrpcClient},
-    transaction::{ForeignAccount, TransactionKernel, TransactionRequestBuilder},
+    transaction::{ForeignAccount, TransactionRequestBuilder},
     ClientError, Word,
 };
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
-
-fn create_library(
-    library_path: &str,
-    source_code: &str,
-) -> Result<Arc<Library>, Box<dyn std::error::Error>> {
-    let source_manager = Arc::new(DefaultSourceManager::default());
-    let assembler = TransactionKernel::assembler_with_source_manager(source_manager.clone());
-    let module = Module::parser(ModuleKind::Library).parse_str(
-        AssemblyPath::new(library_path),
-        source_code,
-        source_manager,
-    )?;
-    let library = assembler.assemble_library([module])?;
-    Ok(library)
-}
 
 #[tokio::main]
 async fn main() -> Result<(), ClientError> {
@@ -586,15 +540,9 @@ async fn main() -> Result<(), ClientError> {
             &u64::from(counter_contract_id.prefix()).to_string(),
         );
 
-    let account_component_lib = create_library(
-        "external_contract::count_reader_contract",
-        &count_reader_code,
-    )
-    .unwrap();
-
     let tx_script = client
         .code_builder()
-        .with_dynamically_linked_library(&account_component_lib)
+        .with_dynamically_linked_library(count_reader_component.component_code())
         .unwrap()
         .compile_tx_script(&script_code)
         .unwrap();

--- a/docs/src/rust-client/mappings_in_masm_how_to.md
+++ b/docs/src/rust-client/mappings_in_masm_how_to.md
@@ -146,19 +146,11 @@ Below is the Rust code that deploys the smart contract, creates the transaction 
 
 ```rust no_run
 use miden_client::auth::NoAuth;
-use miden_client::transaction::TransactionKernel;
 use rand::RngCore;
 use std::{fs, path::Path, sync::Arc};
 
 use miden_client::{
-    assembly::{
-        Assembler,
-        CodeBuilder,
-        DefaultSourceManager,
-        Module,
-        ModuleKind,
-        Path as AssemblyPath,
-    },
+    assembly::CodeBuilder,
     builder::ClientBuilder,
     keystore::FilesystemKeyStore,
     rpc::{Endpoint, GrpcClient},
@@ -173,21 +165,6 @@ use miden_client::{
     },
     Felt, Word,
 };
-
-fn create_library(
-    assembler: Assembler,
-    library_path: &str,
-    source_code: &str,
-) -> Result<std::sync::Arc<miden_client::assembly::Library>, Box<dyn std::error::Error>> {
-    let source_manager = Arc::new(DefaultSourceManager::default());
-    let module = Module::parser(ModuleKind::Library).parse_str(
-        AssemblyPath::new(library_path),
-        source_code,
-        source_manager.clone(),
-    )?;
-    let library = assembler.clone().assemble_library([module])?;
-    Ok(library)
-}
 
 #[tokio::main]
 async fn main() -> Result<(), ClientError> {
@@ -221,9 +198,6 @@ async fn main() -> Result<(), ClientError> {
     // Load the MASM file for the counter contract
     let file_path = Path::new("../masm/accounts/mapping_example_contract.masm");
     let account_code = fs::read_to_string(file_path).unwrap();
-
-    // Prepare assembler (debug mode = true)
-    let assembler: Assembler = TransactionKernel::assembler();
 
     // Using an empty storage value in slot 0 since this is usually reserved
     // for the account pub_key and metadata
@@ -274,18 +248,10 @@ async fn main() -> Result<(), ClientError> {
     let script_code =
         fs::read_to_string(Path::new("../masm/scripts/mapping_example_script.masm")).unwrap();
 
-    // Create the library from the account source code using the helper function.
-    let account_component_lib = create_library(
-        assembler.clone(),
-        "miden_by_example::mapping_example_contract",
-        &account_code,
-    )
-    .unwrap();
-
-    // Compile the transaction script with the library.
+    // Compile the transaction script, dynamically linking the account component library.
     let tx_script = client
         .code_builder()
-        .with_dynamically_linked_library(&account_component_lib)
+        .with_dynamically_linked_library(mapping_contract_component.component_code())
         .unwrap()
         .compile_tx_script(&script_code)
         .unwrap();

--- a/docs/src/rust-client/network_transactions_tutorial.md
+++ b/docs/src/rust-client/network_transactions_tutorial.md
@@ -163,21 +163,12 @@ use miden_client::{
 };
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
 use miden_client::auth::{self, AuthSchemeId, AuthSingleSig};
-use miden_client::transaction::TransactionKernel;
 use miden_client::{
     account::{
         component::AccountComponentMetadata, AccountBuilder, AccountComponent, AccountStorageMode,
         AccountType, StorageSlot, StorageSlotName,
     },
-    assembly::{
-        Assembler,
-        CodeBuilder,
-        DefaultSourceManager,
-        Library,
-        Module,
-        ModuleKind,
-        Path as AssemblyPath,
-    },
+    assembly::CodeBuilder,
 };
 use rand::RngCore;
 use tokio::time::{sleep, Duration};
@@ -212,22 +203,6 @@ async fn wait_for_tx(
         sleep(Duration::from_secs(2)).await;
     }
     Ok(())
-}
-
-/// Creates a Miden library from the provided account code and library path.
-fn create_library(
-    account_code: String,
-    library_path: &str,
-) -> Result<std::sync::Arc<Library>, Box<dyn std::error::Error>> {
-    let assembler: Assembler = TransactionKernel::assembler();
-    let source_manager = Arc::new(DefaultSourceManager::default());
-    let module = Module::parser(ModuleKind::Library).parse_str(
-        AssemblyPath::new(library_path),
-        account_code,
-        source_manager.clone(),
-    )?;
-    let library = assembler.clone().assemble_library([module])?;
-    Ok(library)
 }
 
 #[tokio::main]
@@ -328,7 +303,7 @@ let counter_contract = AccountBuilder::new(init_seed)
     .account_type(AccountType::RegularAccountImmutableCode) // Immutable code
     .storage_mode(AccountStorageMode::Network) // Stored on network
     .with_auth_component(auth::NoAuth) // No authentication required
-    .with_component(counter_component)
+    .with_component(counter_component.clone())
     .build()
     .unwrap();
 
@@ -356,14 +331,9 @@ println!("\n[STEP 3] Deploy network counter smart contract");
 
 let script_code = fs::read_to_string(Path::new("../masm/scripts/counter_script.masm")).unwrap();
 
-let account_code = fs::read_to_string(Path::new("../masm/accounts/counter.masm")).unwrap();
-let library_path = "external_contract::counter_contract";
-
-let library = create_library(account_code, library_path).unwrap();
-
 let tx_script = client
     .code_builder()
-    .with_dynamically_linked_library(&library)?
+    .with_dynamically_linked_library(counter_component.component_code())?
     .compile_tx_script(&script_code)?;
 
 let tx_increment_request = TransactionRequestBuilder::new()
@@ -401,11 +371,6 @@ println!("\n[STEP 4] Creating a network note for network counter contract");
 
 let network_note_code =
     fs::read_to_string(Path::new("../masm/notes/network_increment_note.masm")).unwrap();
-let account_code = fs::read_to_string(Path::new("../masm/accounts/counter.masm")).unwrap();
-
-let library_path = "external_contract::counter_contract";
-let library = create_library(account_code, library_path).unwrap();
-
 // Create and submit the network note that will increment the counter
 // Generate a random serial number for the note
 let serial_num = client.rng().draw_word();
@@ -413,7 +378,7 @@ let serial_num = client.rng().draw_word();
 // Compile the note script with the counter contract library
 let note_script = client
     .code_builder()
-    .with_dynamically_linked_library(&library)?
+    .with_dynamically_linked_library(counter_component.component_code())?
     .compile_note_script(&network_note_code)?;
 
 // Create note recipient with empty storage
@@ -516,21 +481,12 @@ use miden_client::{
 };
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
 use miden_client::auth::{self, AuthSchemeId, AuthSingleSig};
-use miden_client::transaction::TransactionKernel;
 use miden_client::{
     account::{
         component::AccountComponentMetadata, AccountBuilder, AccountComponent, AccountStorageMode,
         AccountType, StorageSlot, StorageSlotName,
     },
-    assembly::{
-        Assembler,
-        CodeBuilder,
-        DefaultSourceManager,
-        Library,
-        Module,
-        ModuleKind,
-        Path as AssemblyPath,
-    },
+    assembly::CodeBuilder,
 };
 use rand::RngCore;
 use tokio::time::{sleep, Duration};
@@ -565,22 +521,6 @@ async fn wait_for_tx(
         sleep(Duration::from_secs(2)).await;
     }
     Ok(())
-}
-
-/// Creates a Miden library from the provided account code and library path.
-fn create_library(
-    account_code: String,
-    library_path: &str,
-) -> Result<std::sync::Arc<Library>, Box<dyn std::error::Error>> {
-    let assembler: Assembler = TransactionKernel::assembler();
-    let source_manager = Arc::new(DefaultSourceManager::default());
-    let module = Module::parser(ModuleKind::Library).parse_str(
-        AssemblyPath::new(library_path),
-        account_code,
-        source_manager.clone(),
-    )?;
-    let library = assembler.clone().assemble_library([module])?;
-    Ok(library)
 }
 
 #[tokio::main]
@@ -668,7 +608,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .account_type(AccountType::RegularAccountImmutableCode) // Immutable code
         .storage_mode(AccountStorageMode::Network) // Stored on network
         .with_auth_component(auth::NoAuth) // No authentication required
-        .with_component(counter_component)
+        .with_component(counter_component.clone())
         .build()
         .unwrap();
 
@@ -686,14 +626,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let script_code = fs::read_to_string(Path::new("../masm/scripts/counter_script.masm")).unwrap();
 
-    let account_code = fs::read_to_string(Path::new("../masm/accounts/counter.masm")).unwrap();
-    let library_path = "external_contract::counter_contract";
-
-    let library = create_library(account_code, library_path).unwrap();
-
     let tx_script = client
         .code_builder()
-        .with_dynamically_linked_library(&library)?
+        .with_dynamically_linked_library(counter_component.component_code())?
         .compile_tx_script(&script_code)?;
 
     let tx_increment_request = TransactionRequestBuilder::new()
@@ -721,11 +656,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let network_note_code =
         fs::read_to_string(Path::new("../masm/notes/network_increment_note.masm")).unwrap();
-    let account_code = fs::read_to_string(Path::new("../masm/accounts/counter.masm")).unwrap();
-
-    let library_path = "external_contract::counter_contract";
-    let library = create_library(account_code, library_path).unwrap();
-
     // Create and submit the network note that will increment the counter
     // Generate a random serial number for the note
     let serial_num = client.rng().draw_word();
@@ -733,7 +663,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Compile the note script with the counter contract library
     let note_script = client
         .code_builder()
-        .with_dynamically_linked_library(&library)?
+        .with_dynamically_linked_library(counter_component.component_code())?
         .compile_note_script(&network_note_code)?;
 
     // Create note recipient with empty inputs

--- a/docs/src/rust-client/oracle_tutorial.md
+++ b/docs/src/rust-client/oracle_tutorial.md
@@ -53,14 +53,7 @@ Copy and paste the following code into your `src/main.rs` file:
 
 ```rust no_run
 use miden_client::{
-    assembly::{
-        Assembler,
-        CodeBuilder,
-        DefaultSourceManager,
-        Module,
-        ModuleKind,
-        Path as AssemblyPath,
-    },
+    assembly::CodeBuilder,
     builder::ClientBuilder,
     keystore::FilesystemKeyStore,
     rpc::{
@@ -71,7 +64,7 @@ use miden_client::{
     Client, ClientError,
 };
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
-use miden_client::{auth::NoAuth, transaction::TransactionKernel};
+use miden_client::auth::NoAuth;
 use miden_client::{
     account::{
         component::AccountComponentMetadata, AccountComponent, AccountId, AccountStorageMode,
@@ -169,21 +162,6 @@ pub async fn get_oracle_foreign_accounts(
     Ok(foreign_accounts)
 }
 
-fn create_library(
-    assembler: Assembler,
-    library_path: &str,
-    source_code: &str,
-) -> Result<std::sync::Arc<miden_client::assembly::Library>, Box<dyn std::error::Error>> {
-    let source_manager = Arc::new(DefaultSourceManager::default());
-    let module = Module::parser(ModuleKind::Library).parse_str(
-        AssemblyPath::new(library_path),
-        source_code,
-        source_manager.clone(),
-    )?;
-    let library = assembler.clone().assemble_library([module])?;
-    Ok(library)
-}
-
 #[tokio::main]
 async fn main() -> Result<(), ClientError> {
     // -------------------------------------------------------------------------
@@ -266,14 +244,9 @@ async fn main() -> Result<(), ClientError> {
     let script_path = Path::new("../masm/scripts/oracle_reader_script.masm");
     let script_code = fs::read_to_string(script_path).unwrap();
 
-    let assembler = TransactionKernel::assembler();
-    let library_path = "external_contract::oracle_reader";
-    let account_component_lib =
-        create_library(assembler.clone(), library_path, &contract_code).unwrap();
-
     let tx_script = client
         .code_builder()
-        .with_dynamically_linked_library(&account_component_lib)
+        .with_dynamically_linked_library(contract_component.component_code())
         .unwrap()
         .compile_tx_script(&script_code)
         .unwrap();

--- a/docs/src/rust-client/public_account_interaction_tutorial.md
+++ b/docs/src/rust-client/public_account_interaction_tutorial.md
@@ -121,18 +121,10 @@ end
 Copy and paste the following code into your `src/main.rs` file:
 
 ```rust no_run
-use miden_client::transaction::TransactionKernel;
 use std::{fs, path::Path, sync::Arc};
 
 use miden_client::{
     account::AccountId,
-    assembly::{
-        Assembler,
-        DefaultSourceManager,
-        Module,
-        ModuleKind,
-        Path as AssemblyPath,
-    },
     builder::ClientBuilder,
     keystore::FilesystemKeyStore,
     rpc::{Endpoint, GrpcClient},
@@ -140,21 +132,6 @@ use miden_client::{
     ClientError,
 };
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
-
-fn create_library(
-    assembler: Assembler,
-    library_path: &str,
-    source_code: &str,
-) -> Result<std::sync::Arc<miden_client::assembly::Library>, Box<dyn std::error::Error>> {
-    let source_manager = Arc::new(DefaultSourceManager::default());
-    let module = Module::parser(ModuleKind::Library).parse_str(
-        AssemblyPath::new(library_path),
-        source_code,
-        source_manager.clone(),
-    )?;
-    let library = assembler.clone().assemble_library([module])?;
-    Ok(library)
-}
 
 #[tokio::main]
 async fn main() -> Result<(), ClientError> {
@@ -248,17 +225,14 @@ let script_code = fs::read_to_string(script_path).unwrap();
 let counter_path = Path::new("../masm/accounts/counter.masm");
 let counter_code = fs::read_to_string(counter_path).unwrap();
 
-let assembler = TransactionKernel::assembler();
-let account_component_lib = create_library(
-    assembler.clone(),
-    "external_contract::counter_contract",
-    &counter_code,
-)
-.unwrap();
+let counter_component_code = client
+    .code_builder()
+    .compile_component_code("external_contract::counter_contract", &counter_code)
+    .unwrap();
 
 let tx_script = client
     .code_builder()
-    .with_dynamically_linked_library(&account_component_lib)
+    .with_dynamically_linked_library(&counter_component_code)
     .unwrap()
     .compile_tx_script(&script_code)
     .unwrap();
@@ -302,18 +276,10 @@ println!(
 The final `src/main.rs` file should look like this:
 
 ```rust no_run
-use miden_client::transaction::TransactionKernel;
 use std::{fs, path::Path, sync::Arc};
 
 use miden_client::{
     account::AccountId,
-    assembly::{
-        Assembler,
-        DefaultSourceManager,
-        Module,
-        ModuleKind,
-        Path as AssemblyPath,
-    },
     builder::ClientBuilder,
     keystore::FilesystemKeyStore,
     rpc::{Endpoint, GrpcClient},
@@ -321,21 +287,6 @@ use miden_client::{
     ClientError,
 };
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
-
-fn create_library(
-    assembler: Assembler,
-    library_path: &str,
-    source_code: &str,
-) -> Result<std::sync::Arc<miden_client::assembly::Library>, Box<dyn std::error::Error>> {
-    let source_manager = Arc::new(DefaultSourceManager::default());
-    let module = Module::parser(ModuleKind::Library).parse_str(
-        AssemblyPath::new(library_path),
-        source_code,
-        source_manager.clone(),
-    )?;
-    let library = assembler.clone().assemble_library([module])?;
-    Ok(library)
-}
 
 #[tokio::main]
 async fn main() -> Result<(), ClientError> {
@@ -397,17 +348,14 @@ async fn main() -> Result<(), ClientError> {
     let counter_path = Path::new("../masm/accounts/counter.masm");
     let counter_code = fs::read_to_string(counter_path).unwrap();
 
-    let assembler = TransactionKernel::assembler();
-    let account_component_lib = create_library(
-        assembler.clone(),
-        "external_contract::counter_contract",
-        &counter_code,
-    )
-    .unwrap();
+    let counter_component_code = client
+        .code_builder()
+        .compile_component_code("external_contract::counter_contract", &counter_code)
+        .unwrap();
 
     let tx_script = client
         .code_builder()
-        .with_dynamically_linked_library(&account_component_lib)
+        .with_dynamically_linked_library(&counter_component_code)
         .unwrap()
         .compile_tx_script(&script_code)
         .unwrap();

--- a/rust-client/src/bin/counter_contract_deploy.rs
+++ b/rust-client/src/bin/counter_contract_deploy.rs
@@ -7,33 +7,15 @@ use miden_client::{
         AccountStorageMode, AccountType, StorageSlot, StorageSlotName,
     },
     address::NetworkId,
-    assembly::{
-        CodeBuilder, DefaultSourceManager, Library, Module, ModuleKind,
-        Path as AssemblyPath,
-    },
+    assembly::CodeBuilder,
     auth::NoAuth,
     builder::ClientBuilder,
     keystore::FilesystemKeyStore,
     rpc::{Endpoint, GrpcClient},
-    transaction::{TransactionKernel, TransactionRequestBuilder},
+    transaction::TransactionRequestBuilder,
     ClientError, Word,
 };
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
-
-fn create_library(
-    library_path: &str,
-    source_code: &str,
-) -> Result<Arc<Library>, Box<dyn std::error::Error>> {
-    let source_manager = Arc::new(DefaultSourceManager::default());
-    let assembler = TransactionKernel::assembler_with_source_manager(source_manager.clone());
-    let module = Module::parser(ModuleKind::Library).parse_str(
-        AssemblyPath::new(library_path),
-        source_code,
-        source_manager,
-    )?;
-    let library = assembler.assemble_library([module])?;
-    Ok(library)
-}
 
 #[tokio::main]
 async fn main() -> Result<(), ClientError> {
@@ -115,16 +97,9 @@ async fn main() -> Result<(), ClientError> {
     let script_path = Path::new("../masm/scripts/counter_script.masm");
     let script_code = fs::read_to_string(script_path).unwrap();
 
-    // Create a library from the counter contract code
-    let account_component_lib = create_library(
-        "external_contract::counter_contract",
-        &counter_code,
-    )
-    .unwrap();
-
     let tx_script = client
         .code_builder()
-        .with_dynamically_linked_library(&account_component_lib)
+        .with_dynamically_linked_library(counter_component.component_code())
         .unwrap()
         .compile_tx_script(&script_code)
         .unwrap();

--- a/rust-client/src/bin/counter_contract_fpi.rs
+++ b/rust-client/src/bin/counter_contract_fpi.rs
@@ -7,33 +7,15 @@ use miden_client::{
         component::AccountComponentMetadata, AccountBuilder, AccountComponent, AccountId,
         AccountStorageMode, AccountType, StorageSlot, StorageSlotName,
     },
-    assembly::{
-        CodeBuilder, DefaultSourceManager, Library, Module, ModuleKind,
-        Path as AssemblyPath,
-    },
+    assembly::CodeBuilder,
     auth::NoAuth,
     builder::ClientBuilder,
     keystore::FilesystemKeyStore,
     rpc::{domain::account::AccountStorageRequirements, Endpoint, GrpcClient},
-    transaction::{ForeignAccount, TransactionKernel, TransactionRequestBuilder},
+    transaction::{ForeignAccount, TransactionRequestBuilder},
     ClientError, Word,
 };
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
-
-fn create_library(
-    library_path: &str,
-    source_code: &str,
-) -> Result<Arc<Library>, Box<dyn std::error::Error>> {
-    let source_manager = Arc::new(DefaultSourceManager::default());
-    let assembler = TransactionKernel::assembler_with_source_manager(source_manager.clone());
-    let module = Module::parser(ModuleKind::Library).parse_str(
-        AssemblyPath::new(library_path),
-        source_code,
-        source_manager,
-    )?;
-    let library = assembler.assemble_library([module])?;
-    Ok(library)
-}
 
 #[tokio::main]
 async fn main() -> Result<(), ClientError> {
@@ -180,15 +162,9 @@ async fn main() -> Result<(), ClientError> {
             &u64::from(counter_contract_id.prefix()).to_string(),
         );
 
-    let account_component_lib = create_library(
-        "external_contract::count_reader_contract",
-        &count_reader_code,
-    )
-    .unwrap();
-
     let tx_script = client
         .code_builder()
-        .with_dynamically_linked_library(&account_component_lib)
+        .with_dynamically_linked_library(count_reader_component.component_code())
         .unwrap()
         .compile_tx_script(&script_code)
         .unwrap();

--- a/rust-client/src/bin/counter_contract_fpi.rs
+++ b/rust-client/src/bin/counter_contract_fpi.rs
@@ -99,7 +99,7 @@ async fn main() -> Result<(), ClientError> {
 
     // Define the Counter Contract account id from counter contract deploy
     let (_, counter_contract_id) =
-        AccountId::from_bech32("mtst1apsd609q5966cqra992t4a00tgstrkfk").unwrap();
+        AccountId::from_bech32("mtst1az2nu8k3jwtzvqzvpjdp45dn3qrmdgzx").unwrap();
 
     println!("counter contract id: {:?}", counter_contract_id);
 

--- a/rust-client/src/bin/counter_contract_increment.rs
+++ b/rust-client/src/bin/counter_contract_increment.rs
@@ -41,7 +41,7 @@ async fn main() -> Result<(), ClientError> {
 
     // Define the Counter Contract account id from counter contract deploy
     let (_, counter_contract_id) =
-        AccountId::from_bech32("mtst1apsd609q5966cqra992t4a00tgstrkfk").unwrap();
+        AccountId::from_bech32("mtst1az2nu8k3jwtzvqzvpjdp45dn3qrmdgzx").unwrap();
 
     client
         .import_account_by_id(counter_contract_id)

--- a/rust-client/src/bin/counter_contract_increment.rs
+++ b/rust-client/src/bin/counter_contract_increment.rs
@@ -2,31 +2,13 @@ use std::{fs, path::Path, sync::Arc};
 
 use miden_client::{
     account::{AccountId, StorageSlotName},
-    assembly::{
-        DefaultSourceManager, Library, Module, ModuleKind, Path as AssemblyPath,
-    },
     builder::ClientBuilder,
     keystore::FilesystemKeyStore,
     rpc::{Endpoint, GrpcClient},
-    transaction::{TransactionKernel, TransactionRequestBuilder},
+    transaction::TransactionRequestBuilder,
     ClientError,
 };
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
-
-fn create_library(
-    library_path: &str,
-    source_code: &str,
-) -> Result<Arc<Library>, Box<dyn std::error::Error>> {
-    let source_manager = Arc::new(DefaultSourceManager::default());
-    let assembler = TransactionKernel::assembler_with_source_manager(source_manager.clone());
-    let module = Module::parser(ModuleKind::Library).parse_str(
-        AssemblyPath::new(library_path),
-        source_code,
-        source_manager,
-    )?;
-    let library = assembler.assemble_library([module])?;
-    Ok(library)
-}
 
 #[tokio::main]
 async fn main() -> Result<(), ClientError> {
@@ -88,15 +70,14 @@ async fn main() -> Result<(), ClientError> {
     let counter_path = Path::new("../masm/accounts/counter.masm");
     let counter_code = fs::read_to_string(counter_path).unwrap();
 
-    let account_component_lib = create_library(
-        "external_contract::counter_contract",
-        &counter_code,
-    )
-    .unwrap();
+    let counter_component_code = client
+        .code_builder()
+        .compile_component_code("external_contract::counter_contract", &counter_code)
+        .unwrap();
 
     let tx_script = client
         .code_builder()
-        .with_dynamically_linked_library(&account_component_lib)
+        .with_dynamically_linked_library(&counter_component_code)
         .unwrap()
         .compile_tx_script(&script_code)
         .unwrap();

--- a/rust-client/src/bin/mapping_example.rs
+++ b/rust-client/src/bin/mapping_example.rs
@@ -6,33 +6,15 @@ use miden_client::{
         component::AccountComponentMetadata, AccountBuilder, AccountComponent,
         AccountStorageMode, AccountType, StorageMap, StorageSlot, StorageSlotName,
     },
-    assembly::{
-        CodeBuilder, DefaultSourceManager, Library, Module, ModuleKind,
-        Path as AssemblyPath,
-    },
+    assembly::CodeBuilder,
     auth::NoAuth,
     builder::ClientBuilder,
     keystore::FilesystemKeyStore,
     rpc::{Endpoint, GrpcClient},
-    transaction::{TransactionKernel, TransactionRequestBuilder},
+    transaction::TransactionRequestBuilder,
     ClientError, Felt, Word,
 };
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
-
-fn create_library(
-    library_path: &str,
-    source_code: &str,
-) -> Result<Arc<Library>, Box<dyn std::error::Error>> {
-    let source_manager = Arc::new(DefaultSourceManager::default());
-    let assembler = TransactionKernel::assembler_with_source_manager(source_manager.clone());
-    let module = Module::parser(ModuleKind::Library).parse_str(
-        AssemblyPath::new(library_path),
-        source_code,
-        source_manager,
-    )?;
-    let library = assembler.assemble_library([module])?;
-    Ok(library)
-}
 
 #[tokio::main]
 async fn main() -> Result<(), ClientError> {
@@ -116,17 +98,10 @@ async fn main() -> Result<(), ClientError> {
     let script_code =
         fs::read_to_string(Path::new("../masm/scripts/mapping_example_script.masm")).unwrap();
 
-    // Create the library from the account source code using the helper function.
-    let account_component_lib = create_library(
-        "miden_by_example::mapping_example_contract",
-        &account_code,
-    )
-    .unwrap();
-
-    // Compile the transaction script with the library.
+    // Compile the transaction script, dynamically linking the account component library.
     let tx_script = client
         .code_builder()
-        .with_dynamically_linked_library(&account_component_lib)
+        .with_dynamically_linked_library(mapping_contract_component.component_code())
         .unwrap()
         .compile_tx_script(&script_code)
         .unwrap();

--- a/rust-client/src/bin/network_notes_counter_contract.rs
+++ b/rust-client/src/bin/network_notes_counter_contract.rs
@@ -6,10 +6,7 @@ use miden_client::{
         AccountStorageMode, AccountType, StorageSlot, StorageSlotName,
     },
     address::NetworkId,
-    assembly::{
-        CodeBuilder, DefaultSourceManager, Library, Module, ModuleKind,
-        Path as AssemblyPath,
-    },
+    assembly::CodeBuilder,
     auth::{self, AuthSchemeId, AuthSecretKey, AuthSingleSig},
     builder::ClientBuilder,
     crypto::FeltRng,
@@ -20,9 +17,7 @@ use miden_client::{
     },
     rpc::{Endpoint, GrpcClient},
     store::TransactionFilter,
-    transaction::{
-        TransactionId, TransactionKernel, TransactionRequestBuilder, TransactionStatus,
-    },
+    transaction::{TransactionId, TransactionRequestBuilder, TransactionStatus},
     Client, ClientError, Felt, Word,
 };
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
@@ -59,22 +54,6 @@ async fn wait_for_tx(
         sleep(Duration::from_secs(2)).await;
     }
     Ok(())
-}
-
-/// Creates a Miden library from the provided account code and library path.
-fn create_library(
-    account_code: String,
-    library_path: &str,
-) -> Result<Arc<Library>, Box<dyn std::error::Error>> {
-    let source_manager = Arc::new(DefaultSourceManager::default());
-    let assembler = TransactionKernel::assembler_with_source_manager(source_manager.clone());
-    let module = Module::parser(ModuleKind::Library).parse_str(
-        AssemblyPath::new(library_path),
-        account_code,
-        source_manager,
-    )?;
-    let library = assembler.assemble_library([module])?;
-    Ok(library)
 }
 
 #[tokio::main]
@@ -163,7 +142,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .account_type(AccountType::RegularAccountImmutableCode) // Immutable code
         .storage_mode(AccountStorageMode::Network) // Stored on network
         .with_auth_component(auth::NoAuth) // No authentication required
-        .with_component(counter_component)
+        .with_component(counter_component.clone())
         .build()
         .unwrap();
 
@@ -181,14 +160,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let script_code = fs::read_to_string(Path::new("../masm/scripts/counter_script.masm")).unwrap();
 
-    let account_code = fs::read_to_string(Path::new("../masm/accounts/counter.masm")).unwrap();
-    let library_path = "external_contract::counter_contract";
-
-    let library = create_library(account_code, library_path).unwrap();
-
     let tx_script = client
         .code_builder()
-        .with_dynamically_linked_library(&library)?
+        .with_dynamically_linked_library(counter_component.component_code())?
         .compile_tx_script(&script_code)?;
 
     let tx_increment_request = TransactionRequestBuilder::new()
@@ -216,10 +190,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let network_note_code =
         fs::read_to_string(Path::new("../masm/notes/network_increment_note.masm")).unwrap();
-    let account_code = fs::read_to_string(Path::new("../masm/accounts/counter.masm")).unwrap();
-
-    let library_path = "external_contract::counter_contract";
-    let library = create_library(account_code, library_path).unwrap();
 
     // Create and submit the network note that will increment the counter
     // Generate a random serial number for the note
@@ -228,7 +198,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Compile the note script with the counter contract library
     let note_script = client
         .code_builder()
-        .with_dynamically_linked_library(&library)?
+        .with_dynamically_linked_library(counter_component.component_code())?
         .compile_note_script(&network_note_code)?;
 
     // Create note recipient with empty inputs

--- a/rust-client/src/bin/oracle_data_query.rs
+++ b/rust-client/src/bin/oracle_data_query.rs
@@ -4,9 +4,7 @@ use miden_client::{
         AccountStorageMode, AccountType, StorageMapKey, StorageSlot, StorageSlotName,
         StorageSlotType,
     },
-    assembly::{
-        CodeBuilder, DefaultSourceManager, Module, ModuleKind, Path as AssemblyPath,
-    },
+    assembly::CodeBuilder,
     auth::NoAuth,
     builder::ClientBuilder,
     keystore::FilesystemKeyStore,
@@ -14,7 +12,7 @@ use miden_client::{
         domain::account::AccountStorageRequirements,
         Endpoint, GrpcClient,
     },
-    transaction::{ForeignAccount, TransactionKernel, TransactionRequestBuilder},
+    transaction::{ForeignAccount, TransactionRequestBuilder},
     Client, ClientError, Word,
 };
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
@@ -108,21 +106,6 @@ pub async fn get_oracle_foreign_accounts(
     Ok(foreign_accounts)
 }
 
-fn create_library(
-    library_path: &str,
-    source_code: &str,
-) -> Result<Arc<miden_client::assembly::Library>, Box<dyn std::error::Error>> {
-    let source_manager = Arc::new(DefaultSourceManager::default());
-    let assembler = TransactionKernel::assembler_with_source_manager(source_manager.clone());
-    let module = Module::parser(ModuleKind::Library).parse_str(
-        AssemblyPath::new(library_path),
-        source_code,
-        source_manager,
-    )?;
-    let library = assembler.assemble_library([module])?;
-    Ok(library)
-}
-
 #[tokio::main]
 async fn main() -> Result<(), ClientError> {
     // -------------------------------------------------------------------------
@@ -207,13 +190,9 @@ async fn main() -> Result<(), ClientError> {
     let script_path = Path::new("../masm/scripts/oracle_reader_script.masm");
     let script_code = fs::read_to_string(script_path).unwrap();
 
-    let library_path = "external_contract::oracle_reader";
-    let account_component_lib =
-        create_library(library_path, &contract_code).unwrap();
-
     let tx_script = client
         .code_builder()
-        .with_dynamically_linked_library(&account_component_lib)
+        .with_dynamically_linked_library(contract_component.component_code())
         .unwrap()
         .compile_tx_script(&script_code)
         .unwrap();


### PR DESCRIPTION
I think https://github.com/0xMiden/tutorials/pull/187 got closed when the base branch got merged.

Official guidance should be to utilize the `CodeBuilder`, which is also provided by `Client`. Recently mixing source managers in assemblers started resulting in internal panics (https://github.com/0xMiden/miden-vm/issues/2778), so we need to make guidance as consistent as possible. This also simplifies code a bunch. cc @Keinberger @BrianSeong99 

Closes #188.