### PR TITLE
chore: format network increment note

### DIFF
--- a/masm/notes/network_increment_note.masm
+++ b/masm/notes/network_increment_note.masm
@@ -1,5 +1,7 @@
 use external_contract::counter_contract
 
+# => [pad(16)]
 begin
     call.counter_contract::increment_count
+    # => [pad(16)]
 end


### PR DESCRIPTION
Starts the MASM formatting pass for #190 with the single-file pattern Philipp suggested.

This only updates masm/notes/network_increment_note.masm so we can confirm the style before touching the wider set.

Checks:
- git diff --check