### PR TITLE
docs: fix duplicate 'a' in oracle tutorial

### DIFF
--- a/docs/src/rust-client/oracle_tutorial.md
+++ b/docs/src/rust-client/oracle_tutorial.md
@@ -330,7 +330,7 @@ masm/
 
 ### Oracle price reader smart contract
 
-Below is our oracle price reader contract. It has a a single exported procedure: `get_price`
+Below is our oracle price reader contract. It has a single exported procedure: `get_price`
 
 The import `miden::tx` contains the `tx::execute_foreign_procedure` which we will use to read the price from the oracle contract.
 


### PR DESCRIPTION
## Summary
Fixed duplicate word "a" in the oracle price reader contract description.

## Changes
- Changed "It has a a single exported procedure" → "It has a single exported procedure"

## Location
`docs/src/rust-client/oracle_tutorial.md` (line 333)

## Note
This same typo appears in the miden-docs repository across multiple versions (0.11, 0.12, 0.13, 0.14), which are likely auto-generated from this source file. Fixing it here should propagate to those versions on the next documentation build.