### PR TITLE
fix(docs): fix broken "Continue Learning" links in miden-bank Part 8

### DIFF
--- a/docs/src/miden-bank/08-complete-flows.md
+++ b/docs/src/miden-bank/08-complete-flows.md
@@ -281,9 +281,9 @@ You've completed the Miden Bank tutorial! You now understand:
 
 ### Continue Learning
 
-- **[Testing with MockChain](https://docs.miden.xyz/builder/tutorials/rust-compiler/testing)** - Deep dive into testing patterns
-- **[Debugging Guide](https://docs.miden.xyz/builder/tutorials/rust-compiler/debugging)** - Troubleshoot common issues
-- **[Common Pitfalls](https://docs.miden.xyz/builder/tutorials/rust-compiler/pitfalls)** - Avoid known gotchas
+- **[Testing with MockChain](https://docs.miden.xyz/builder/tutorials/helpers/testing)** - Deep dive into testing patterns
+- **[Debugging Guide](https://docs.miden.xyz/builder/tutorials/helpers/debugging)** - Troubleshoot common issues
+- **[Common Pitfalls](https://docs.miden.xyz/builder/tutorials/helpers/pitfalls)** - Avoid known gotchas
 
 ### Build More
 


### PR DESCRIPTION
Fix broken "Continue Learning" links in Part 8 of the Miden Bank tutorial.

All three links pointed to a non-existent path `/builder/tutorials/rust-compiler/`
instead of the correct `/builder/tutorials/helpers/`.

Changes:
08-complete-flows.md:
  `/builder/tutorials/rust-compiler/testing`  → `/builder/tutorials/helpers/testing`
  `/builder/tutorials/rust-compiler/debugging` → `/builder/tutorials/helpers/debugging`
  `/builder/tutorials/rust-compiler/pitfalls`  → `/builder/tutorials/helpers/pitfalls`

Test plan:
Documentation-only change; no code paths affected.