### PR TITLE
fix(docs): fix broken links across rust-client and web-client tutorials

### DIFF
--- a/docs/src/rust-client/create_deploy_tutorial.md
+++ b/docs/src/rust-client/create_deploy_tutorial.md
@@ -20,7 +20,7 @@ In this tutorial, we will create a Miden account for _Alice_ and deploy a fungib
 
 ## Prerequisites
 
-Before you begin, ensure that a Miden node is running locally in a separate terminal window. To get the Miden node running locally, you can follow the instructions on the [Miden Node Setup](../miden_node_setup.md) page.
+Before you begin, ensure that a Miden node is running locally in a separate terminal window. To get the Miden node running locally, you can follow the instructions on the [Miden Node Setup](../miden_node_setup) page.
 
 ## Public vs. private accounts & notes
 

--- a/docs/src/web-client/react_wallet_tutorial.md
+++ b/docs/src/web-client/react_wallet_tutorial.md
@@ -932,5 +932,5 @@ The `SignerContextValue` interface requires:
 Now that you've built a React wallet, explore these related topics:
 
 - [Creating Multiple Notes in a Single Transaction](./creating_multiple_notes_tutorial.md) - Learn about batch operations
-- [Miden React SDK Reference](https://github.com/0xMiden/miden-client/tree/main/packages/react-sdk) - Full API documentation
-- [Miden Documentation](https://docs.miden.io/) - Core Miden concepts
+- [Miden React SDK Reference](https://docs.miden.xyz/builder/tools/clients/react-sdk/) - Full API documentation
+- [Miden Documentation](https://docs.miden.xyz/) - Core Miden concepts

--- a/docs/src/web-client/unauthenticated_note_how_to.md
+++ b/docs/src/web-client/unauthenticated_note_how_to.md
@@ -9,7 +9,7 @@ _Using unauthenticated notes for optimistic note consumption with the Miden clie
 
 ## Overview
 
-In this tutorial, we will explore how to leverage unauthenticated notes on Miden to settle transactions faster than the blocktime using the Miden client. Unauthenticated notes are essentially UTXOs that have not yet been fully committed into a block. This feature allows the notes to be created and consumed within the same batch during [batch production](https://0xmiden.github.io/miden-docs/imported/miden-base/src/blockchain.html#batch-production).
+In this tutorial, we will explore how to leverage unauthenticated notes on Miden to settle transactions faster than the blocktime using the Miden client. Unauthenticated notes are essentially UTXOs that have not yet been fully committed into a block. This feature allows the notes to be created and consumed within the same batch during [batch production](https://docs.miden.xyz/reference/protocol/blockchain#batch-production).
 
 When using unauthenticated notes, both the creation and consumption of notes can happen within the same batch, enabling faster-than-blocktime settlement. This is particularly powerful for applications requiring high-frequency transactions or optimistic settlement patterns.
 


### PR DESCRIPTION
Fix broken links across three tutorial files.

Changes:
rust-client/create_deploy_tutorial.md:
  `../miden_node_setup.md` → `../miden_node_setup`

web-client/unauthenticated_note_how_to.md:
  `https://0xmiden.github.io/miden-docs/imported/miden-base/src/blockchain.html#batch-production`
  → `https://docs.miden.xyz/reference/protocol/blockchain#batch-production`

web-client/react_wallet_tutorial.md:
  `https://github.com/0xMiden/miden-client/tree/main/packages/react-sdk`
  → `https://docs.miden.xyz/builder/tools/clients/react-sdk/`

  `https://docs.miden.io/`
  → `https://docs.miden.xyz/`

Test plan:
Documentation-only change; no code paths affected.