### PR TITLE
fix(rust-client): use delegated (remote) proving in the delegated-proving tutorial

### DIFF
--- a/docs/src/rust-client/delegated_proving_tutorial.md
+++ b/docs/src/rust-client/delegated_proving_tutorial.md
@@ -32,8 +32,9 @@ The only downside of using delegated proving is that it reduces the privacy of t
 
 Anyone can run their own delegated prover server. If you are building a product on Miden, it may make sense to run your own delegated prover server for your users. To run your own delegated proving server, follow the instructions here: https://crates.io/crates/miden-remote-prover.
 
-To keep this tutorial runnable without external services, the code below uses a local prover. The
-flow is the same if you swap in `RemoteTransactionProver` and point it at your delegated prover.
+This tutorial performs real delegated proving against the public Miden testnet prover at
+`https://tx-prover.testnet.miden.io` using `RemoteTransactionProver`. To use your own delegated
+prover instead, point `RemoteTransactionProver` at its URL.
 
 ## Step 1: Initialize your repository
 
@@ -58,7 +59,7 @@ tokio = { version = "1.46", features = ["rt-multi-thread", "net", "macros", "fs"
 ## Step 2: Initialize the client and prover and construct transactions
 
 Similarly to previous tutorials, we must instantiate the client.
-We construct a `LocalTransactionProver` for this walkthrough.
+We construct a `RemoteTransactionProver` pointed at the public Miden testnet delegated prover for this walkthrough.
 
 ```rust no_run
 use miden_client::auth::AuthSecretKey;
@@ -71,13 +72,8 @@ use miden_client::{
     builder::ClientBuilder,
     keystore::{FilesystemKeyStore, Keystore},
     rpc::{Endpoint, GrpcClient},
-    transaction::{
-        LocalTransactionProver,
-        ProvingOptions,
-        TransactionProver,
-        TransactionRequestBuilder,
-    },
-    ClientError,
+    transaction::{TransactionProver, TransactionRequestBuilder},
+    ClientError, RemoteTransactionProver,
 };
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
 use miden_client::account::{AccountBuilder, AccountType};
@@ -123,10 +119,15 @@ async fn main() -> Result<(), ClientError> {
     keystore.add_key(&key_pair, alice_account.id()).await.unwrap();
 
     // -------------------------------------------------------------------------
-    // Setup the local tx prover
+    // Set up the delegated (remote) tx prover
     // -------------------------------------------------------------------------
-    let local_tx_prover = LocalTransactionProver::new(ProvingOptions::default());
-    let tx_prover: Arc<dyn TransactionProver> = Arc::new(local_tx_prover);
+    // Delegated proving outsources ZK proof generation to a remote service. This is
+    // the public Miden testnet prover; run your own
+    // (https://crates.io/crates/miden-remote-prover) and swap the URL to use it.
+    // The constant `miden_client::grpc_support::TESTNET_PROVER_ENDPOINT` holds this
+    // same URL.
+    let remote_tx_prover = RemoteTransactionProver::new("https://tx-prover.testnet.miden.io");
+    let tx_prover: Arc<dyn TransactionProver> = Arc::new(remote_tx_prover);
 
     // We use a dummy transaction request to showcase delegated proving.
     // The only effect of this tx should be increasing Alice's nonce.
@@ -148,8 +149,8 @@ async fn main() -> Result<(), ClientError> {
         .execute_transaction(alice_account.id(), transaction_request)
         .await?;
 
-    // Step 2: Prove the transaction using the local prover
-    println!("Proving transaction with local prover...");
+    // Step 2: Prove the transaction using the delegated (remote) prover
+    println!("Proving transaction with the delegated prover...");
     let proven_transaction = client.prove_transaction_with(&tx_result, tx_prover).await?;
 
     // Step 3: Submit the proven transaction
@@ -163,7 +164,7 @@ async fn main() -> Result<(), ClientError> {
         .apply_transaction(&tx_result, submission_height)
         .await?;
 
-    println!("Transaction submitted successfully using local prover!");
+    println!("Transaction submitted successfully using the delegated prover!");
 
     client.sync_state().await.unwrap();
 
@@ -188,9 +189,13 @@ cargo run --release
 The output will look like this:
 
 ```text
-Latest block: 226954
-Alice initial account balance: Ok(1000)
-Alice final account balance: Ok(900)
+Latest block: 488706
+Alice nonce initial: 0
+Executing transaction...
+Proving transaction with the delegated prover...
+Submitting proven transaction...
+Transaction submitted successfully using the delegated prover!
+Alice nonce has increased: 1
 ```
 
 ### Running the example

--- a/rust-client/src/bin/delegated_prover.rs
+++ b/rust-client/src/bin/delegated_prover.rs
@@ -7,10 +7,8 @@ use miden_client::{
     builder::ClientBuilder,
     keystore::{FilesystemKeyStore, Keystore},
     rpc::{Endpoint, GrpcClient},
-    transaction::{
-        LocalTransactionProver, ProvingOptions, TransactionProver, TransactionRequestBuilder,
-    },
-    ClientError,
+    transaction::{TransactionProver, TransactionRequestBuilder},
+    ClientError, RemoteTransactionProver,
 };
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
 
@@ -55,10 +53,15 @@ async fn main() -> Result<(), ClientError> {
     keystore.add_key(&key_pair, alice_account.id()).await.unwrap();
 
     // -------------------------------------------------------------------------
-    // Setup the local tx prover
+    // Set up the delegated (remote) tx prover
     // -------------------------------------------------------------------------
-    let local_tx_prover = LocalTransactionProver::new(ProvingOptions::default());
-    let tx_prover: Arc<dyn TransactionProver> = Arc::new(local_tx_prover);
+    // Delegated proving outsources ZK proof generation to a remote service. This is
+    // the public Miden testnet prover; run your own
+    // (https://crates.io/crates/miden-remote-prover) and swap the URL to use it.
+    // The constant `miden_client::grpc_support::TESTNET_PROVER_ENDPOINT` holds this
+    // same URL.
+    let remote_tx_prover = RemoteTransactionProver::new("https://tx-prover.testnet.miden.io");
+    let tx_prover: Arc<dyn TransactionProver> = Arc::new(remote_tx_prover);
 
     // We use a dummy transaction request to showcase delegated proving.
     // The only effect of this tx should be increasing Alice's nonce.
@@ -80,8 +83,8 @@ async fn main() -> Result<(), ClientError> {
         .execute_transaction(alice_account.id(), transaction_request)
         .await?;
 
-    // Step 2: Prove the transaction using the local prover
-    println!("Proving transaction with local prover...");
+    // Step 2: Prove the transaction using the delegated (remote) prover
+    println!("Proving transaction with the delegated prover...");
     let proven_transaction = client.prove_transaction_with(&tx_result, tx_prover).await?;
 
     // Step 3: Submit the proven transaction
@@ -95,7 +98,7 @@ async fn main() -> Result<(), ClientError> {
         .apply_transaction(&tx_result, submission_height)
         .await?;
 
-    println!("Transaction submitted successfully using local prover!");
+    println!("Transaction submitted successfully using the delegated prover!");
 
     client.sync_state().await.unwrap();
 


### PR DESCRIPTION
## Overview

The "Delegated Proving" tutorial (`delegated_prover.rs` + `delegated_proving_tutorial.md`) is supposed to teach delegated proving, but it actually proved locally: it built a `LocalTransactionProver`, and the doc even admitted "to keep this tutorial runnable without external services, the code below uses a local prover." Miden runs a public testnet delegated prover, so the tutorial can just do the real thing.

This PR points the tutorial at the hosted testnet delegated prover so it performs actual delegated (remote) proving.

## Key Changes

- `rust-client/src/bin/delegated_prover.rs`: build `RemoteTransactionProver::new("https://tx-prover.testnet.miden.io")` instead of `LocalTransactionProver`, and drop it into the existing `prove_transaction_with(...)` call. Both implement `TransactionProver`, so the execute, prove, submit, apply flow is unchanged. Updated the "local prover" comment/print strings to say delegated.
- `docs/src/rust-client/delegated_proving_tutorial.md`: the same change inside the `rust no_run` block, corrected the prose that said the tutorial uses a local prover, and replaced the expected-output transcript, which was wrong (it showed account-balance lines this binary never prints) with the real nonce output.

## Rationale

No new dependency: `RemoteTransactionProver` already ships with the `miden-client` the tutorial depends on (it is the same type `ClientBuilder::for_testnet()` uses). I used the URL as a string literal rather than the `TESTNET_PROVER_ENDPOINT` constant so a reader can see the endpoint and knows they can point it at their own prover. The privacy caveat (delegated proving reveals the transaction inputs, so it is not appropriate for the hash-preimage note tutorial) stays.

## Tests

Ran `delegated_prover` against testnet: the remote prover generated the proof and Alice's nonce went 0 to 1 (exit 0). `cargo test --doc` (17 passed, 0 failed) and `prettier --check` are green.
