### PR TITLE
fix(rust-client): wait for the final note-consume tx to commit in the custom-note and MASM-note tutorials

### DIFF
--- a/docs/src/rust-client/creating_notes_in_masm_tutorial.md
+++ b/docs/src/rust-client/creating_notes_in_masm_tutorial.md
@@ -229,7 +229,8 @@ use miden_client::{
         PartialNoteMetadata,
     },
     rpc::{Endpoint, GrpcClient},
-    transaction::TransactionRequestBuilder,
+    store::TransactionFilter,
+    transaction::{TransactionId, TransactionRequestBuilder, TransactionStatus},
     Client, ClientError, Felt,
 };
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
@@ -315,6 +316,38 @@ async fn wait_for_notes(
             account_id.id().to_bech32(NetworkId::Testnet)
         );
         sleep(Duration::from_secs(3)).await;
+    }
+    Ok(())
+}
+
+/// Waits for a specific transaction to be committed.
+async fn wait_for_tx(
+    client: &mut Client<FilesystemKeyStore>,
+    tx_id: TransactionId,
+) -> Result<(), ClientError> {
+    loop {
+        client.sync_state().await?;
+
+        // Check transaction status
+        let txs = client
+            .get_transactions(TransactionFilter::Ids(vec![tx_id]))
+            .await?;
+        let tx_committed = if !txs.is_empty() {
+            matches!(txs[0].status, TransactionStatus::Committed { .. })
+        } else {
+            false
+        };
+
+        if tx_committed {
+            println!("✅ transaction {} committed", tx_id.to_hex());
+            break;
+        }
+
+        println!(
+            "Transaction {} not yet committed. Waiting...",
+            tx_id.to_hex()
+        );
+        sleep(Duration::from_secs(2)).await;
     }
     Ok(())
 }
@@ -489,6 +522,8 @@ async fn main() -> Result<(), ClientError> {
         tx_id
     );
 
+    wait_for_tx(&mut client, tx_id).await?;
+
     Ok(())
 }
 ```
@@ -502,26 +537,27 @@ cargo run --release
 The output will look something like this:
 
 ```text
-Latest block: 4186
+Latest block: 488715
 
 [STEP 1] Creating new accounts
-Alice's account ID: "mtst1aqnztxg76d5exyr7ja05pzhvegx3jc84"
-Bob's account ID: "mtst1az0mfyzm3xqe2yrezucvmc24dv5gset0"
+Alice's account ID: "mtst1azvwquwfvh0jyytq0dk9xya9tvhvu935"
+Bob's account ID: "mtst1ap9hwvau7sy9tvtka6smn0ev7cxtgt03"
 
 Deploying a new fungible faucet.
-Faucet account ID: "mtst1ary7kplxvatxkgpes4llcc53yu8px433"
+Faucet account ID: "mtst1apj3jthkj4mweyf7qt254h5m5gdemp9u"
 
 [STEP 2] Mint tokens with P2ID
-Minted tokens. TX: 0x8577213057226b7d0545d73f6e1bc416354a324089450cb859f5784c133d4cc0
-0 consumable notes found for account mtst1aqnztxg76d5exyr7ja05pzhvegx3jc84. Waiting...
-Consumed minted note. TX: 0xd93e791d3283192df121de4cf938a4f9cfaed48f4e593e1b82d147e2d642b7bd
+Minted tokens. TX: 0xf3c8f183aeefb086ca4a63f2a6f34535ea4217849e8e870033f892503302fb7d
+0 consumable notes found for account mtst1azvwquwfvh0jyytq0dk9xya9tvhvu935. Waiting...
+Consumed minted note. TX: 0x2d31ce827549d8bf35d1c3613610f8388d6c2369dbd1aa34f4f3406f86fdff55
 
 [STEP 3] Create iterative output note
-View transaction on MidenScan: https://testnet.midenscan.com/tx/0xcd71a1d87c60ab7632a7836723fff4014b02992ef7ea5d3fe2030a971e795a8a
+View transaction on MidenScan: https://testnet.midenscan.com/tx/0xadabf7a920ee27bf1fabd3b02e8e6f3d80f84ece31a23d73f27b0b56bbc2fdc3
 
 [STEP 4] Bob consumes the note and creates a copy
-Consumed Note Tx on MidenScan: https://testnet.midenscan.com/tx/0x4d91519c180874c931480fa58620f864fd7c7aada35ada2d40082291298084bb
-Account delta: AccountVaultDelta { fungible: FungibleAssetDelta({V0(Accoun
+Consumed Note Tx on MidenScan: https://testnet.midenscan.com/tx/0xa003d298db5e7de263a8b98930b6e75336c3cca7cd4a090c707edb6a7f061ad5
+Transaction 0xa003d298db5e7de263a8b98930b6e75336c3cca7cd4a090c707edb6a7f061ad5 not yet committed. Waiting...
+✅ transaction 0xa003d298db5e7de263a8b98930b6e75336c3cca7cd4a090c707edb6a7f061ad5 committed
 ```
 
 ---

--- a/docs/src/rust-client/custom_note_how_to.md
+++ b/docs/src/rust-client/custom_note_how_to.md
@@ -394,6 +394,8 @@ async fn main() -> Result<(), ClientError> {
         tx_id
     );
 
+    wait_for_tx(&mut client, tx_id).await?;
+
     Ok(())
 }
 ```
@@ -401,7 +403,7 @@ async fn main() -> Result<(), ClientError> {
 The output of our program will look something like this:
 
 ```text
-Latest block: 226943
+Latest block: 488704
 
 [STEP 1] Creating new accounts
 Alice's account ID: "<testnet_account_id>"
@@ -411,19 +413,21 @@ Deploying a new fungible faucet.
 Faucet account ID: "<testnet_account_id>"
 
 [STEP 2] Mint tokens with P2ID
-Note 0x88d8c4a50c0e6342e58026b051fb6038867de21d3bd3963aec67fd6c45861faf not found. Waiting...
-Note 0x88d8c4a50c0e6342e58026b051fb6038867de21d3bd3963aec67fd6c45861faf not found. Waiting...
-✅ note found 0x88d8c4a50c0e6342e58026b051fb6038867de21d3bd3963aec67fd6c45861faf
+Minted tokens. TX: 0x970265408eb22068b22ec677f6ad09a2524913ab11b3dbf010e4cae73587e2e3
+Transaction 0x970265408eb22068b22ec677f6ad09a2524913ab11b3dbf010e4cae73587e2e3 not yet committed. Waiting...
+✅ transaction 0x970265408eb22068b22ec677f6ad09a2524913ab11b3dbf010e4cae73587e2e3 committed
+Consumed minted note. TX: 0x47850a0c44d9e147b8866285c24ba05a0d4bed0a99c1f25a13f32e57feecfe1b
 
 [STEP 3] Create custom note
-digest: RpoDigest([14371582251229115050, 1386930022051078873, 17689831064175867466, 9632123050519021080])
-note hash: "0x14c66143377223e090e5b4da0d1e5ce6c6521622ad5b92161a704a25c915769b"
-View transaction on MidenScan: https://testnet.midenscan.com/tx/0xffbee228a2c6283efe958c6b3cd31af88018c029221b413b0f23fcfacb2cb611
+digest: Word([14206540680072267069, 9571949196318390099, 5950603493574130513, 3457190364553631046])
+note hash: "0xf48f362f1817bbc5575e0bb8b77c496dd67e4b85d8ff45d21dff5743de2b174d"
+View transaction on MidenScan: https://testnet.midenscan.com/tx/0x9911ef1b9d2b066e017de187b7c1f8d95012748366358474b11adc91e49971b5
 
 [STEP 4] Bob consumes the Custom Note with Correct Secret
-Consumed Note Tx on MidenScan: https://testnet.midenscan.com/tx/0xe6c8bb7b469e03dcacd8f1f400011a781e96ad4266ede11af8e711379e85b929
+Consumed Note Tx on MidenScan: https://testnet.midenscan.com/tx/0x2a7a192b692984ae649dd1a13d15e4b79178e9e554615ffec7426e25e75193fa
 
-account delta: AccountVaultDelta { fungible: FungibleAssetDelta({V0(AccountIdV0 { prefix: 6702563556733766432, suffix: 1016103534633728 }): 100}), non_fungible: NonFungibleAssetDelta({}) }
+Transaction 0x2a7a192b692984ae649dd1a13d15e4b79178e9e554615ffec7426e25e75193fa not yet committed. Waiting...
+✅ transaction 0x2a7a192b692984ae649dd1a13d15e4b79178e9e554615ffec7426e25e75193fa committed
 ```
 
 ## Conclusion

--- a/rust-client/src/bin/hash_preimage_note.rs
+++ b/rust-client/src/bin/hash_preimage_note.rs
@@ -265,5 +265,7 @@ async fn main() -> Result<(), ClientError> {
         tx_id
     );
 
+    wait_for_tx(&mut client, tx_id).await?;
+
     Ok(())
 }

--- a/rust-client/src/bin/note_creation_in_masm.rs
+++ b/rust-client/src/bin/note_creation_in_masm.rs
@@ -21,7 +21,8 @@ use miden_client::{
         PartialNoteMetadata,
     },
     rpc::{Endpoint, GrpcClient},
-    transaction::TransactionRequestBuilder,
+    store::TransactionFilter,
+    transaction::{TransactionId, TransactionRequestBuilder, TransactionStatus},
     Client, ClientError, Felt,
 };
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
@@ -107,6 +108,38 @@ async fn wait_for_notes(
             account_id.id().to_bech32(NetworkId::Testnet)
         );
         sleep(Duration::from_secs(3)).await;
+    }
+    Ok(())
+}
+
+/// Waits for a specific transaction to be committed.
+async fn wait_for_tx(
+    client: &mut Client<FilesystemKeyStore>,
+    tx_id: TransactionId,
+) -> Result<(), ClientError> {
+    loop {
+        client.sync_state().await?;
+
+        // Check transaction status
+        let txs = client
+            .get_transactions(TransactionFilter::Ids(vec![tx_id]))
+            .await?;
+        let tx_committed = if !txs.is_empty() {
+            matches!(txs[0].status, TransactionStatus::Committed { .. })
+        } else {
+            false
+        };
+
+        if tx_committed {
+            println!("✅ transaction {} committed", tx_id.to_hex());
+            break;
+        }
+
+        println!(
+            "Transaction {} not yet committed. Waiting...",
+            tx_id.to_hex()
+        );
+        sleep(Duration::from_secs(2)).await;
     }
     Ok(())
 }
@@ -280,6 +313,8 @@ async fn main() -> Result<(), ClientError> {
         "Consumed Note Tx on MidenScan: https://testnet.midenscan.com/tx/{:?}",
         tx_id
     );
+
+    wait_for_tx(&mut client, tx_id).await?;
 
     Ok(())
 }


### PR DESCRIPTION
## Overview

Two of the note tutorials submit their final "Bob consumes the note" transaction and then immediately print a MidenScan link and exit, without confirming the transaction committed. Every earlier step in the same files already waits for commitment, so the final and most important step was the only unconfirmed one, and the printed happy-path output could show a link for a transaction that had not actually landed yet.

This PR makes both tutorials wait for the final consume to commit before exiting.

## Key Changes

- `rust-client/src/bin/hash_preimage_note.rs`: call the file's existing `wait_for_tx` helper on the final consume transaction (one line).
- `rust-client/src/bin/note_creation_in_masm.rs`: this file had no `wait_for_tx` helper, so I ported it verbatim from `hash_preimage_note.rs` and added the imports it needs (`store::TransactionFilter`, `TransactionId`, `TransactionStatus`), then call it on the final consume.
- Both doc pages (`custom_note_how_to.md`, `creating_notes_in_masm_tutorial.md`): mirrored the code change inside the `rust no_run` block and regenerated the expected-output transcript from a real run. Regenerating also cleaned up some pre-existing staleness: the custom-note transcript had an old `note found` STEP-2 poll, a fabricated `account delta` line, and `RpoDigest` where the binary now prints `Word`; the MASM-note transcript was truncated mid-line.

## Rationale

Correctness was never the issue here: these are local transactions, so a wrong secret or a broken note script already fails at proving and errors out. This is a robustness and output-honesty fix, so the tutorial's final line reflects a note that actually got consumed on-chain, matching how the rest of each file already behaves.

## Tests

Ran both binaries against testnet: each now prints `✅ transaction <id> committed` at STEP 4 and exits 0. `cargo test --doc` (17 passed, 0 failed) and `prettier --check` are green.
