### PR TITLE
chore: standardize MASM comments for counter tutorials

### DIFF
--- a/CONTRIBUTION_NOTE.md
+++ b/CONTRIBUTION_NOTE.md
@@ -1,1 +1,0 @@
-This branch prepares a focused MASM formatting contribution for 0xMiden/tutorials#190.

--- a/CONTRIBUTION_NOTE.md
+++ b/CONTRIBUTION_NOTE.md
@@ -1,0 +1,1 @@
+This branch prepares a focused MASM formatting contribution for 0xMiden/tutorials#190.

--- a/masm/accounts/auth/no_auth.masm
+++ b/masm/accounts/auth/no_auth.masm
@@ -1,5 +1,11 @@
 use miden::protocol::native_account
 
+#! Authorizes a transaction without signature checks and increments the account nonce.
+#!
+#! Inputs:  []
+#! Outputs: []
+#!
+#! Invocation: auth script
 @auth_script
 pub proc auth__basic
     exec.native_account::incr_nonce drop

--- a/masm/accounts/count_reader.masm
+++ b/masm/accounts/count_reader.masm
@@ -7,20 +7,28 @@ use miden::core::sys
 # The storage slot where the copied count is stored.
 const COUNT_READER_SLOT = word("miden::tutorials::count_reader")
 
-# => [account_id_suffix, account_id_prefix, PROC_HASH(4), foreign_procedure_inputs(16)]
+#! Copies a count from a foreign account into this account's storage.
+#!
+#! Inputs:  [account_id_suffix, account_id_prefix, PROC_HASH, foreign_procedure_inputs]
+#! Outputs: []
+#!
+#! Where:
+#! - account_id_{prefix,suffix} identify the foreign account.
+#! - PROC_HASH is the foreign procedure hash.
+#! - foreign_procedure_inputs are the inputs reserved for the foreign procedure call.
+#!
+#! Invocation: call
 pub proc copy_count
     exec.tx::execute_foreign_procedure
     # => [count, pad(12)]
 
     push.COUNT_READER_SLOT[0..2]
-    # [slot_id_prefix, slot_id_suffix, count, pad(12)]
+    # => [slot_id_prefix, slot_id_suffix, count, pad(12)]
 
     exec.native_account::set_item
     # => [OLD_VALUE, pad(12)]
 
     dropw dropw dropw dropw
-    # => []
 
     exec.sys::truncate_stack
-    # => []
 end

--- a/masm/accounts/counter.masm
+++ b/masm/accounts/counter.masm
@@ -5,28 +5,29 @@ use miden::core::sys
 
 const COUNTER_SLOT = word("miden::tutorials::counter")
 
+#! Description: Reads the current counter value from active account storage.
 #! Inputs:  []
 #! Outputs: [count]
+#! Invocation: exec
 pub proc get_count
     push.COUNTER_SLOT[0..2] exec.active_account::get_item
     # => [count]
 
     exec.sys::truncate_stack
-    # => [count]
 end
 
+#! Description: Increments the active account counter by one and stores the updated value.
 #! Inputs:  []
 #! Outputs: []
+#! Invocation: exec
 pub proc increment_count
     push.COUNTER_SLOT[0..2] exec.active_account::get_item
     # => [count]
 
     add.1
-    # => [count+1]
+    # => [count]
 
     push.COUNTER_SLOT[0..2] exec.native_account::set_item
-    # => []
 
     exec.sys::truncate_stack
-    # => []
 end


### PR DESCRIPTION
## Summary

This is a focused follow-up for #190.

- add structured `#!` documentation to the counter account procedures
- document the `count_reader` foreign-procedure inputs and invocation
- document the no-auth auth script
- normalize stack comment syntax and remove redundant obvious-state comments

The scope is intentionally small so the formatting convention can be reviewed before applying the same pattern across the rest of the tutorial MASM files.

Closes part of #190.