### PR TITLE
docs: add missing cd src before library file creation

### DIFF
--- a/docs/src/web-client/counter_contract_tutorial.md
+++ b/docs/src/web-client/counter_contract_tutorial.md
@@ -103,6 +103,7 @@ export default function Home() {
 The counter contract code lives in a separate `.masm` file. Create a `lib/masm/` directory and add the contract file:
 
 ```bash
+cd src
 mkdir -p lib/masm
 ```
 
@@ -183,6 +184,7 @@ webpack: (config, { isServer }) => {
 Create the file `lib/incrementCounterContract.ts`:
 
 ```bash
+cd src
 touch lib/incrementCounterContract.ts
 ```
 

--- a/docs/src/web-client/create_deploy_tutorial.md
+++ b/docs/src/web-client/create_deploy_tutorial.md
@@ -77,9 +77,10 @@ The Miden client is your gateway to interact with the Miden blockchain. It handl
 
 ### Create the library file
 
-First, we'll create a separate file for our blockchain logic. In the project root, create a folder `lib/` and inside it `lib/react/createMintConsume.tsx` (React) or `lib/createMintConsume.ts` (TypeScript):
+First, we'll create a separate file for our blockchain logic. Inside `src/`, create a folder `lib/` and inside it `lib/react/createMintConsume.tsx` (React) or `lib/createMintConsume.ts` (TypeScript):
 
 ```bash
+cd src
 mkdir -p lib
 ```
 

--- a/docs/src/web-client/creating_multiple_notes_tutorial.md
+++ b/docs/src/web-client/creating_multiple_notes_tutorial.md
@@ -138,6 +138,7 @@ export default function Home() {
 Create `lib/react/multiSendWithDelegatedProver.tsx` (React) or `lib/multiSendWithDelegatedProver.ts` (TypeScript) and add the following code. This snippet initializes the Miden client.
 
 ```
+cd src
 mkdir -p lib
 ```
 

--- a/docs/src/web-client/foreign_procedure_invocation_tutorial.md
+++ b/docs/src/web-client/foreign_procedure_invocation_tutorial.md
@@ -118,6 +118,7 @@ export default function Home() {
 The MASM (Miden Assembly) code for our smart contracts lives in separate `.masm` files. Create a `lib/masm/` directory and add the two contract files:
 
 ```bash
+cd src
 mkdir -p lib/masm
 ```
 
@@ -234,6 +235,7 @@ webpack: (config, { isServer }) => {
 Create the file `lib/foreignProcedureInvocation.ts` and add the following code.
 
 ```bash
+cd src
 touch lib/foreignProcedureInvocation.ts
 ```
 

--- a/docs/src/web-client/unauthenticated_note_how_to.md
+++ b/docs/src/web-client/unauthenticated_note_how_to.md
@@ -154,6 +154,7 @@ export default function Home() {
 Create the library file and add the following code:
 
 ```bash
+cd src
 mkdir -p lib
 ```
 


### PR DESCRIPTION
Web tutorials created library files without `cd src` first, so `lib/` landed outside Next.js `src/` while imports expect `../lib`.

Closes #115